### PR TITLE
add custom memory access calls

### DIFF
--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -2,6 +2,7 @@
 #define IMAGE_H
 
 #include <unordered_map>
+#include <optional>
 
 #include "image_print_stream.h"
 #include "mem_image.h"

--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -51,9 +51,9 @@ class MIPSImage {
     /**
      * @brief Override this method to implement custom memory read behavior
      * @param addr The address to read from
-     * @returns true if the read was successful, false otherwise
+     * @returns The value at the address, or std::nullopt if the read was unsuccessful
      */
-    virtual bool custom_memory_read(mem_addr) { return false; }
+    virtual std::optional<mem_word> custom_memory_read(mem_addr) { return std::nullopt; }
 
     /**
      * @brief Override this method to implement custom memory write behavior

--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -50,19 +50,50 @@ class MIPSImage {
     std::unordered_map<mem_addr, breakpoint> &breakpoints();
 
     /**
-     * @brief Override this method to implement custom memory read behavior
+     * @brief Override this method to implement custom memory read word behavior
      * @param addr The address to read from
      * @returns The value at the address, or std::nullopt if the read was unsuccessful
      */
-    virtual std::optional<mem_word> custom_memory_read(mem_addr) { return std::nullopt; }
+    virtual std::optional<mem_word> custom_memory_read_word(mem_addr) { return std::nullopt; }
 
     /**
-     * @brief Override this method to implement custom memory write behavior
+     * @brief Override this method to implement custom memory write word behavior
      * @param addr The address to write to
      * @param value The value to write
      * @returns true if the write was successful, false otherwise
      */
-    virtual bool custom_memory_write(mem_addr, mem_word) { return false; }
+    virtual bool custom_memory_write_word(mem_addr, mem_word) { return false; }
+
+    /**
+     * @brief Override this method to implement custom memory read half behavior
+     * @param addr The address to read from
+     * @returns The value at the address, or std::nullopt if the read was unsuccessful
+     */
+    virtual std::optional<mem_word> custom_memory_read_half(mem_addr) { return std::nullopt; }
+
+    /**
+     * @brief Override this method to implement custom memory write half behavior
+     * @param addr The address to write to
+     * @param value The value to write
+     * @returns true if the write was successful, false otherwise
+     */
+    virtual bool custom_memory_write_half(mem_addr, mem_word) { return false; }
+
+    /**
+     * @brief Override this method to implement custom memory read byte behavior
+     * @param addr The address to read from
+     * @returns The value at the address, or std::nullopt if the read was unsuccessful
+     */
+    virtual std::optional<mem_word> custom_memory_read_byte(mem_addr) { return std::nullopt; }
+
+    /**
+     * @brief Override this method to implement custom memory write byte behavior
+     * @param addr The address to write to
+     * @param value The value to write
+     * @returns true if the write was successful, false otherwise
+     */
+    virtual bool custom_memory_write_byte(mem_addr, mem_word) { return false; }
+
 
     std::streambuf *get_std_out_buf();
     std::streambuf *get_std_err_buf();

--- a/spim/CPU/mem.cpp
+++ b/spim/CPU/mem.cpp
@@ -372,6 +372,10 @@ read_mem_inst(MIPSImage &img, mem_addr addr)
 reg_word
 read_mem_byte(MIPSImage &img, mem_addr addr)
 {
+  std::optional<reg_word> custom_read = img.custom_memory_read(addr);
+  if (custom_read.has_value())
+    return custom_read.value();
+
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top))
     return img.mem_image().data_seg_b [addr - DATA_BOT];
   else if ((addr >= img.mem_image().stack_bot) && (addr < STACK_TOP))
@@ -388,6 +392,10 @@ read_mem_byte(MIPSImage &img, mem_addr addr)
 reg_word
 read_mem_half(MIPSImage &img, mem_addr addr)
 {
+  std::optional<reg_word> custom_read = img.custom_memory_read(addr);
+  if (custom_read.has_value())
+    return custom_read.value();
+
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top) && !(addr & 0x1))
     return img.mem_image().data_seg_h [(addr - DATA_BOT) >> 1];
   else if ((addr >= img.mem_image().stack_bot) && (addr < STACK_TOP) && !(addr & 0x1))
@@ -404,6 +412,10 @@ read_mem_half(MIPSImage &img, mem_addr addr)
 reg_word
 read_mem_word(MIPSImage &img, mem_addr addr)
 {
+  std::optional<reg_word> custom_read = img.custom_memory_read(addr);
+  if (custom_read.has_value())
+    return custom_read.value();
+
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top) && !(addr & 0x3))
     return img.mem_image().data_seg [(addr - DATA_BOT) >> 2];
   else if ((addr >= img.mem_image().stack_bot) && (addr < STACK_TOP) && !(addr & 0x3))
@@ -434,6 +446,9 @@ void
 set_mem_byte(MIPSImage &img, mem_addr addr, reg_word value)
 {
   img.mem_image().data_modified = true;
+  if (img.custom_memory_write(addr, value))
+    return;
+
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top))
     img.mem_image().data_seg_b [addr - DATA_BOT] = (BYTE_TYPE) value;
   else if ((addr >= img.mem_image().stack_bot) && (addr < STACK_TOP))
@@ -451,6 +466,9 @@ void
 set_mem_half(MIPSImage &img, mem_addr addr, reg_word value)
 {
   img.mem_image().data_modified = true;
+  if (img.custom_memory_write(addr, value))
+    return;
+
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top) && !(addr & 0x1))
     img.mem_image().data_seg_h [(addr - DATA_BOT) >> 1] = (short) value;
   else if ((addr >= img.mem_image().stack_bot) && (addr < STACK_TOP) && !(addr & 0x1))
@@ -468,6 +486,9 @@ void
 set_mem_word(MIPSImage &img, mem_addr addr, reg_word value)
 {
   img.mem_image().data_modified = true;
+  if (img.custom_memory_write(addr, value))
+    return;
+
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top) && !(addr & 0x3))
     img.mem_image().data_seg [(addr - DATA_BOT) >> 2] = (mem_word) value;
   else if ((addr >= img.mem_image().stack_bot) && (addr < STACK_TOP) && !(addr & 0x3))

--- a/spim/CPU/mem.cpp
+++ b/spim/CPU/mem.cpp
@@ -38,7 +38,7 @@
 #include "reg.h"
 #include "mem.h"
 
-
+#include <optional>
 
 
 

--- a/spim/CPU/mem.cpp
+++ b/spim/CPU/mem.cpp
@@ -372,7 +372,7 @@ read_mem_inst(MIPSImage &img, mem_addr addr)
 reg_word
 read_mem_byte(MIPSImage &img, mem_addr addr)
 {
-  std::optional<reg_word> custom_read = img.custom_memory_read(addr);
+  std::optional<reg_word> custom_read = img.custom_memory_read_byte(addr);
   if (custom_read.has_value())
     return custom_read.value();
 
@@ -392,7 +392,7 @@ read_mem_byte(MIPSImage &img, mem_addr addr)
 reg_word
 read_mem_half(MIPSImage &img, mem_addr addr)
 {
-  std::optional<reg_word> custom_read = img.custom_memory_read(addr);
+  std::optional<reg_word> custom_read = img.custom_memory_read_half(addr);
   if (custom_read.has_value())
     return custom_read.value();
 
@@ -412,7 +412,7 @@ read_mem_half(MIPSImage &img, mem_addr addr)
 reg_word
 read_mem_word(MIPSImage &img, mem_addr addr)
 {
-  std::optional<reg_word> custom_read = img.custom_memory_read(addr);
+  std::optional<reg_word> custom_read = img.custom_memory_read_word(addr);
   if (custom_read.has_value())
     return custom_read.value();
 
@@ -446,7 +446,7 @@ void
 set_mem_byte(MIPSImage &img, mem_addr addr, reg_word value)
 {
   img.mem_image().data_modified = true;
-  if (img.custom_memory_write(addr, value))
+  if (img.custom_memory_write_byte(addr, value))
     return;
 
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top))
@@ -466,7 +466,7 @@ void
 set_mem_half(MIPSImage &img, mem_addr addr, reg_word value)
 {
   img.mem_image().data_modified = true;
-  if (img.custom_memory_write(addr, value))
+  if (img.custom_memory_write_half(addr, value))
     return;
 
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top) && !(addr & 0x1))
@@ -486,7 +486,7 @@ void
 set_mem_word(MIPSImage &img, mem_addr addr, reg_word value)
 {
   img.mem_image().data_modified = true;
-  if (img.custom_memory_write(addr, value))
+  if (img.custom_memory_write_word(addr, value))
     return;
 
   if ((addr >= DATA_BOT) && (addr < img.mem_image().data_top) && !(addr & 0x3))


### PR DESCRIPTION
* change `MIPSImage::custom_memory_read` to return a `std::optional<mem_word>`
* add `MIPSImage::custom_memory_read` calls to `read_mem` functions
* add `MIPSImage::custom_memory_write` calls to `set_mem` functions