### PR TITLE
Fixed memory leaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,11 @@ add_subdirectory(spim/CPU)
 
 target_link_libraries(wasm spim)
 
-target_compile_options(wasm PRIVATE -I. -I$CPU -Wall -pedantic -Wextra -Wunused -Wno-write-strings -x c++)
+target_compile_options(wasm PRIVATE -pthread -I. -I$CPU -Wall -pedantic -Wextra -Wunused -Wno-write-strings -x c++)
+target_link_options(wasm PRIVATE -pthread)
 
 if (EMSCRIPTEN)
     target_link_options(wasm PRIVATE
-        -pthread
         -lm
         -lembind
         "SHELL:-s EXIT_RUNTIME=0"
@@ -108,7 +108,6 @@ if (EMSCRIPTEN)
     endif()
 
     target_compile_options(wasm PRIVATE
-        -pthread
         "SHELL:-s NO_DISABLE_EXCEPTION_CATCHING"
     )
 
@@ -117,7 +116,6 @@ if (EMSCRIPTEN)
         COMMAND mv wasm.* ../${DIST_DIR}/
     )
 else()
-    target_link_options(wasm PRIVATE "-pthread")
     if (CMAKE_BUILD_TYPE IN_LIST DEBUG_PROFILES)
         target_link_options(wasm PRIVATE "${EXTRA_DEBUG_LINKER_FLAGS}")
     endif()

--- a/spim/CPU/CMakeLists.txt
+++ b/spim/CPU/CMakeLists.txt
@@ -27,7 +27,7 @@ BISON_TARGET(MyParser parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser_yacc.cpp
 find_package(FLEX 2.6.4 REQUIRED)
 FLEX_TARGET(MyLexxer scanner.l ${CMAKE_CURRENT_BINARY_DIR}/lex.yy.cpp)
 
-add_compile_options(-Wall -pedantic -Wextra -Wunused -Wno-write-strings -Wno-narrowing -x c++)
+add_compile_options(-pthread -Wall -pedantic -Wextra -Wunused -Wno-write-strings -Wno-narrowing -x c++)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_library(spim STATIC ${Spim_SOURCES} ${BISON_MyParser_OUTPUTS} ${FLEX_MyLexxer_OUTPUTS} )

--- a/spim/CPU/consts.h
+++ b/spim/CPU/consts.h
@@ -1,0 +1,9 @@
+#ifndef CONSTS_H
+#define CONSTS_H
+
+constexpr int K = 1024;
+
+
+#define BYTES_PER_WORD 4	/* On the MIPS processor */
+
+#endif

--- a/spim/CPU/image.cpp
+++ b/spim/CPU/image.cpp
@@ -1,10 +1,16 @@
+#include "inst.h"
 #include "spim.h"
 #include "spim-utils.h"
 #include "image.h"
+#include "sym-tbl.h"
 
 #include <iostream>
 
 MIPSImage::MIPSImage(int ctx) : ctx(ctx), std_out(ctx, std::cout), std_err(ctx, std::cerr) {}
+
+MIPSImage::~MIPSImage() {
+    initialize_symbol_table(*this);
+}
 
 int MIPSImage::get_ctx() const {
     return ctx;

--- a/spim/CPU/image.cpp
+++ b/spim/CPU/image.cpp
@@ -10,6 +10,10 @@ MIPSImage::MIPSImage(int ctx) : ctx(ctx), std_out(ctx, std::cout), std_err(ctx, 
 
 MIPSImage::~MIPSImage() {
     initialize_symbol_table(*this);
+    for (auto it = labels_to_free.begin(); it != labels_to_free.end(); it ++) {
+        free((*it)->name);
+        free(*it);
+    }
 }
 
 int MIPSImage::get_ctx() const {
@@ -26,6 +30,10 @@ reg_image_t &MIPSImage::reg_image() {
 
 label **MIPSImage::get_label_hash_table() {
     return label_hash_table;
+}
+
+void MIPSImage::push_label_to_free_vector(label *label) {
+    labels_to_free.push_back(label);
 }
 
 label *MIPSImage::get_local_labels() {

--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -31,6 +31,7 @@ class MIPSImage {
     // std::unordered_map<mem_addr, label> labels;
     label *local_labels = NULL; // No allocs occur here
     label *label_hash_table[LABEL_HASH_TABLE_SIZE] = {0};
+    std::vector<label *> labels_to_free;
 
     MIPSImagePrintStream std_out;
     MIPSImagePrintStream std_err;
@@ -44,6 +45,7 @@ class MIPSImage {
     reg_image_t &reg_image();
     label **get_label_hash_table();
     label *get_local_labels();
+    void push_label_to_free_vector(label *);
     void set_local_labels(label *);
     const mem_image_t &memview_image() const;
     const reg_image_t &regview_image() const;

--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -29,13 +29,14 @@ class MIPSImage {
 
     std::unordered_map<mem_addr, breakpoint> bkpt_map;
     // std::unordered_map<mem_addr, label> labels;
-    label *local_labels = NULL;
+    label *local_labels = NULL; // No allocs occur here
     label *label_hash_table[LABEL_HASH_TABLE_SIZE] = {0};
 
     MIPSImagePrintStream std_out;
     MIPSImagePrintStream std_err;
   public:
     MIPSImage(int ctx);
+    ~MIPSImage();
 
     int get_ctx() const;
 

--- a/spim/CPU/inst.cpp
+++ b/spim/CPU/inst.cpp
@@ -668,7 +668,6 @@ inst_to_string(MIPSImage &img, mem_addr addr)
       return "";
     }
 
-  ss_init (&ss);
   format_an_inst (img, &ss, inst, addr);
   return ss_to_string (img, &ss);
 }

--- a/spim/CPU/inst.cpp
+++ b/spim/CPU/inst.cpp
@@ -280,7 +280,9 @@ i_type_inst_full_word (MIPSImage &img, int opcode, int rt, int rs, imm_expr *exp
 		{
 		r_type_inst (img, Y_ADDU_OP, 1, 1, rs);
 		}
-	      i_type_inst_free (img, opcode, rt, 1, lower_bits_of_expr (img, const_imm_expr (img, low)));
+          imm_expr *const_expr = const_imm_expr (img, low);
+	      i_type_inst_free (img, opcode, rt, 1, lower_bits_of_expr (img, const_expr));
+          free(const_expr);
 	    }
 	  else
 	    {
@@ -577,7 +579,9 @@ free_inst (instruction *inst)
     /* Don't free the breakpoint insructions since we only have one. */
     {
       if (EXPR (inst))
-	free (EXPR (inst));
+	    free (EXPR (inst));
+      if (SOURCE(inst))
+        free (SOURCE(inst));
       free (inst);
     }
 }

--- a/spim/CPU/inst.cpp
+++ b/spim/CPU/inst.cpp
@@ -1198,7 +1198,7 @@ make_addr_expr (MIPSImage &img, int offs, char *sym, int reg_no)
   else
     {
       expr->reg_no = (unsigned char)reg_no;
-      expr->imm = make_imm_expr (img, offs, (sym ? str_copy (img, sym) : sym), false);
+      expr->imm = make_imm_expr (img, offs, sym, false);
     }
   return (expr);
 }

--- a/spim/CPU/instruction.h
+++ b/spim/CPU/instruction.h
@@ -51,8 +51,8 @@ typedef struct inst_s
     } r_t;
 
   int32 encoding;
-  imm_expr *expr;
-  char *source_line;
+  imm_expr *expr = 0;
+  char *source_line = 0;
 } instruction;
 
 #endif

--- a/spim/CPU/mem.cpp
+++ b/spim/CPU/mem.cpp
@@ -172,7 +172,7 @@ void mem_dump_profile(MIPSImage &img) {
   mem_image_t &mem_image = img.mem_image();
 
   str_stream ss;
-  ss_init(&ss);
+
   FILE *file = NULL;
 
   // TODO: need to standardize this for multiple contexts

--- a/spim/CPU/mem.cpp
+++ b/spim/CPU/mem.cpp
@@ -418,10 +418,17 @@ void
 set_mem_inst(MIPSImage &img, mem_addr addr, instruction* inst)
 {
   img.mem_image().text_modified = true;
-  if ((addr >= TEXT_BOT) && (addr < img.mem_image().text_top) && !(addr & 0x3))
+  if ((addr >= TEXT_BOT) && (addr < img.mem_image().text_top) && !(addr & 0x3)) {
+    if (img.mem_image().text_seg [(addr - TEXT_BOT) >> 2]) {
+        free_inst(img.mem_image().text_seg [(addr - TEXT_BOT) >> 2]);
+    }
     img.mem_image().text_seg [(addr - TEXT_BOT) >> 2] = inst;
-  else if ((addr >= K_TEXT_BOT) && (addr < img.mem_image().k_text_top) && !(addr & 0x3))
+  } else if ((addr >= K_TEXT_BOT) && (addr < img.mem_image().k_text_top) && !(addr & 0x3)) {
+    if (img.mem_image().k_text_seg [(addr - K_TEXT_BOT) >> 2]) {
+        free_inst(img.mem_image().k_text_seg [(addr - K_TEXT_BOT) >> 2]);
+    }
     img.mem_image().k_text_seg [(addr - K_TEXT_BOT) >> 2] = inst;
+  }
   else
     bad_text_write (img, addr, inst);
 }

--- a/spim/CPU/mem.cpp
+++ b/spim/CPU/mem.cpp
@@ -40,15 +40,12 @@
 
 
 
-
-
 /* Local functions: */
 
 static mem_word bad_mem_read (MIPSImage &img, mem_addr addr, int mask);
 static void bad_mem_write (MIPSImage &img, mem_addr addr, mem_word value, int mask);
 static instruction *bad_text_read (MIPSImage &img, mem_addr addr);
 static void bad_text_write (MIPSImage &img, mem_addr addr, instruction *inst);
-static void free_instructions (instruction **inst, int n);
 static mem_word read_memory_mapped_IO (MIPSImage &img, mem_addr addr);
 static void write_memory_mapped_IO (MIPSImage &img, mem_addr addr, mem_word value);
 
@@ -227,7 +224,7 @@ void mem_dump_profile(MIPSImage &img) {
 
 /* Free the storage used by the old instructions in memory. */
 
-static void
+void
 free_instructions (instruction **inst, int n)
 {
   for ( ; n > 0; n --, inst ++)

--- a/spim/CPU/mem.h
+++ b/spim/CPU/mem.h
@@ -41,31 +41,6 @@
 
 #include "image.h"
 
-/* The text boundaries. */
-#define TEXT_BOT ((mem_addr) 0x400000)
-/* Amount to grow text segment when we run out of space for instructions. */
-#define TEXT_CHUNK_SIZE	4096
-
-/* The data boundaries. */
-#define DATA_BOT ((mem_addr) 0x10000000)
-
-/* The stack boundaries. */
-/* Exclusive, but include 4K at top of stack. */
-#define STACK_TOP ((mem_addr) 0x80000000)
-
-/* The kernel text boundaries. */
-#define K_TEXT_BOT ((mem_addr) 0x80000000)
-
-/* The Kernel data boundaries. */
-#define K_DATA_BOT ((mem_addr) 0x90000000)
-
-/* Memory-mapped IO area: */
-#define MM_IO_BOT		((mem_addr) 0xffff0000)
-#define MM_IO_TOP		((mem_addr) 0xffffffff)
-
-#define SPECIAL_BOT		((mem_addr) 0xfffe0000)
-#define SPECIAL_TOP		((mem_addr) 0xffff0000)
-
 
 
 

--- a/spim/CPU/mem_image.h
+++ b/spim/CPU/mem_image.h
@@ -1,14 +1,44 @@
 #ifndef MEM_IMAGE_H
 #define MEM_IMAGE_H
 
+#include "consts.h"
 #include "types.h"
 #include "instruction.h"
+
+#include <stdlib.h>
 
 /* Type of contents of a memory word. */
 
 typedef int32 /*@alt unsigned int @*/ mem_word;
 
 #define BYTE_TYPE signed char
+
+/* The text boundaries. */
+#define TEXT_BOT ((mem_addr) 0x400000)
+/* Amount to grow text segment when we run out of space for instructions. */
+#define TEXT_CHUNK_SIZE	4096
+
+/* The data boundaries. */
+#define DATA_BOT ((mem_addr) 0x10000000)
+
+/* The stack boundaries. */
+/* Exclusive, but include 4K at top of stack. */
+#define STACK_TOP ((mem_addr) 0x80000000)
+
+/* The kernel text boundaries. */
+#define K_TEXT_BOT ((mem_addr) 0x80000000)
+
+/* The Kernel data boundaries. */
+#define K_DATA_BOT ((mem_addr) 0x90000000)
+
+/* Memory-mapped IO area: */
+#define MM_IO_BOT		((mem_addr) 0xffff0000)
+#define MM_IO_TOP		((mem_addr) 0xffffffff)
+
+#define SPECIAL_BOT		((mem_addr) 0xfffe0000)
+#define SPECIAL_TOP		((mem_addr) 0xffff0000)
+
+void free_instructions (instruction **inst, int n);
 
 typedef struct memimage {
 	/* The text segment. */
@@ -48,6 +78,28 @@ typedef struct memimage {
 	mem_addr k_data_top = 0;
 
 	char* prof_file_name = 0;
+
+    ~memimage() {
+        free_instructions(text_seg, (text_top - TEXT_BOT) / BYTES_PER_WORD);
+        free_instructions(k_text_seg, (k_text_top - K_TEXT_BOT) / BYTES_PER_WORD);
+        if (text_seg)
+            free(text_seg);
+        if (text_prof)
+            free(text_prof);
+        if (data_seg)
+            free(data_seg);
+        if (stack_seg)
+            free(stack_seg);
+        if (special_seg)
+            free(special_seg);
+        if (k_text_seg)
+            free(k_text_seg);
+        if (k_text_prof)
+            free(k_text_prof);
+        if (k_data_seg)
+            free(k_data_seg);
+
+    }
 } mem_image_t;
 
 #endif

--- a/spim/CPU/parser.y
+++ b/spim/CPU/parser.y
@@ -1106,7 +1106,7 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 		  if (bare_machine && !accept_pseudo_insts)
 		    yyerror (img, "Immediate form not allowed in bare machine");
 		  else
-		    i_type_inst (img, $1.i == Y_SUB_OP ? Y_ADDI_OP
+		    i_type_inst_free (img, $1.i == Y_SUB_OP ? Y_ADDI_OP
 				 : $1.i == Y_SUBU_OP ? Y_ADDIU_OP
 				 : (fatal_error (img, "Bad SUB_OP\n"), 0),
 				 $2.i,
@@ -2983,7 +2983,9 @@ yyerror (MIPSImage &img, char *s)
 void
 yywarn (MIPSImage &img, char *s)
 {
-  error (img, "spim: (parser) %s on line %d of file %s\n%s", s, line_no, input_file_name, erroneous_line (img));
+  char *line = erroneous_line(img);
+  error (img, "spim: (parser) %s on line %d of file %s\n%s", s, line_no, input_file_name, line);
+  free(line);
 }
 
 

--- a/spim/CPU/parser.y
+++ b/spim/CPU/parser.y
@@ -2359,6 +2359,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 		    noat_flag = true;
 		  else if (streq ((char*)$2.p, "at"))
 		    noat_flag = false;
+          free((char*) $2.p);
 		}
 
 

--- a/spim/CPU/parser.y
+++ b/spim/CPU/parser.y
@@ -533,15 +533,17 @@ LBL_CMD:	OPT_LBL CMD
 OPT_LBL: ID ':' {
 		  /* Call outside of cons_label, since an error sets that variable to NULL. */
 		  label* l = record_label (img,
-		  			   std::get<std::shared_ptr<char>>($1).get(),
+		  			   (char*)$1.p,
 					   text_dir ? current_text_pc (img) : current_data_pc (img),
 					   0);
 		  this_line_labels = cons_label (l, this_line_labels);
+		  free ((char*)$1.p);
 		}
 
 	|	ID '=' EXPR
 		{
-		  label *l = record_label (img, std::get<std::shared_ptr<char>>($1).get(), (mem_addr)std::get<int>($3), 1);
+		  label *l = record_label (img, (char*)$1.p, (mem_addr)$3.i, 1);
+		  free ((char*)$1.p);
 
 		  l->const_flag = 1;
 		  clear_labels (img);
@@ -582,117 +584,117 @@ TERM:		Y_NL
 ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 		{
 		  i_type_inst (img,
-		  		   std::get<int>($1) == Y_LD_POP ? Y_LW_OP : std::get<int>($1),
-			       std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
-		  if (std::get<int>($1) == Y_LD_POP)
+		  		   $1.i == Y_LD_POP ? Y_LW_OP : $1.i,
+			       $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
+		  if ($1.i == Y_LD_POP)
 		    i_type_inst_free (img,
 					  Y_LW_OP,
-				      std::get<int>($2) + 1,
-				      addr_expr_reg (std::get<addr_expr *>($3)),
-				      incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+				      $2.i + 1,
+				      addr_expr_reg ((addr_expr *)$3.p),
+				      incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 							4));
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 	|	LOADC_OPS	COP_REG	ADDRESS
 		{
 		  i_type_inst (img,
-		  		   std::get<int>($1),
-			       std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  		   $1.i,
+			       $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 	|	LOADFP_OPS	F_SRC1	ADDRESS
 		{
 		  i_type_inst (img,
-		  		   std::get<int>($1),
-			       std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  		   $1.i,
+			       $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 	|	LOADI_OPS	DEST	UIMM16
 		{
-		  i_type_inst_free (img, std::get<int>($1), std::get<int>($2), 0, std::get<imm_expr *>($3));
+		  i_type_inst_free (img, $1.i, $2.i, 0, (imm_expr *)$3.p);
 		}
 
 
 	|	Y_LA_POP	DEST	ADDRESS
 		{
-		  if (addr_expr_reg (std::get<addr_expr *>($3)))
-		    i_type_inst (img, Y_ADDI_OP, std::get<int>($2),
-				 addr_expr_reg (std::get<addr_expr *>($3)),
-				 addr_expr_imm (std::get<addr_expr *>($3)));
+		  if (addr_expr_reg ((addr_expr *)$3.p))
+		    i_type_inst (img, Y_ADDI_OP, $2.i,
+				 addr_expr_reg ((addr_expr *)$3.p),
+				 addr_expr_imm ((addr_expr *)$3.p));
 		  else
-		    i_type_inst (img, Y_ORI_OP, std::get<int>($2), 0,
-				 addr_expr_imm (std::get<addr_expr *>($3)));
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		    i_type_inst (img, Y_ORI_OP, $2.i, 0,
+				 addr_expr_imm ((addr_expr *)$3.p));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 
 	|	Y_LI_POP	DEST	IMM32
 		{
-		  i_type_inst_free (img, Y_ORI_OP, std::get<int>($2), 0, std::get<imm_expr *>($3));
+		  i_type_inst_free (img, Y_ORI_OP, $2.i, 0, (imm_expr *)$3.p);
 		}
 
 
 	|	Y_LI_D_POP	F_DEST	Y_FP
 		{
-		  int *x = (int *) std::get<void *>($3);
+		  int *x = (int *) $3.p;
 
           imm_expr *const_expr = const_imm_expr (img, *x);
 		  i_type_inst (img, Y_ORI_OP, 1, 0, const_expr);
           free(const_expr);
-		  r_co_type_inst (img, Y_MTC1_OP, 0, std::get<int>($2), 1);
+		  r_co_type_inst (img, Y_MTC1_OP, 0, $2.i, 1);
           const_expr = const_imm_expr (img, *(x+1));
 		  i_type_inst (img, Y_ORI_OP, 1, 0, const_expr);
           free(const_expr);
-		  r_co_type_inst (img, Y_MTC1_OP, 0, std::get<int>($2) + 1, 1);
+		  r_co_type_inst (img, Y_MTC1_OP, 0, $2.i + 1, 1);
 		}
 
 
 	|	Y_LI_S_POP	F_DEST	Y_FP
 		{
-		  float x = (float) *((double *) std::get<void *>($3));
+		  float x = (float) *((double *) $3.p);
 		  int *y = (int *) &x;
 
           imm_expr *const_expr = const_imm_expr (img, *y);
 		  i_type_inst (img, Y_ORI_OP, 1, 0,const_expr);
           free(const_expr);
-		  r_co_type_inst (img, Y_MTC1_OP, 0, std::get<int>($2), 1);
+		  r_co_type_inst (img, Y_MTC1_OP, 0, $2.i, 1);
 		}
 
 
 	|	Y_ULW_POP	DEST	ADDRESS
 		{
 #ifdef SPIM_BIGENDIAN
-		  i_type_inst (img,Y_LWL_OP, std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
-		  i_type_inst_free (img, Y_LWR_OP, std::get<int>($2),
-				    addr_expr_reg (std::get<addr_expr *>($3)),
-				    incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+		  i_type_inst (img,Y_LWL_OP, $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
+		  i_type_inst_free (img, Y_LWR_OP, $2.i,
+				    addr_expr_reg ((addr_expr *)$3.p),
+				    incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 						      3));
 #else
-		  i_type_inst_free (img, Y_LWL_OP, std::get<int>($2),
-				    addr_expr_reg (std::get<addr_expr *>($3)),
-				    incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+		  i_type_inst_free (img, Y_LWL_OP, $2.i,
+				    addr_expr_reg ((addr_expr *)$3.p),
+				    incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 						      3));
-		  i_type_inst (img, Y_LWR_OP, std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
+		  i_type_inst (img, Y_LWR_OP, $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
 #endif
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 
@@ -700,29 +702,29 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 		{
 #ifdef SPIM_BIGENDIAN
 		  i_type_inst (img,
-		  		   (std::get<int>($1) == Y_ULH_POP ? Y_LB_OP : Y_LBU_OP),
-			       std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
+		  		   ($1.i == Y_ULH_POP ? Y_LB_OP : Y_LBU_OP),
+			       $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
 		  i_type_inst_free (img, Y_LBU_OP, 1,
-				    addr_expr_reg (std::get<addr_expr *>($3)),
-				    incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+				    addr_expr_reg ((addr_expr *)$3.p),
+				    incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 						      1));
 #else
 		  i_type_inst_free (img,
-		  			(std::get<int>($1) == Y_ULH_POP ? Y_LB_OP : Y_LBU_OP),
-				    std::get<int>($2),
-				    addr_expr_reg (std::get<addr_expr *>($3)),
-				    incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+		  			($1.i == Y_ULH_POP ? Y_LB_OP : Y_LBU_OP),
+				    $2.i,
+				    addr_expr_reg ((addr_expr *)$3.p),
+				    incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 						      1));
 		  i_type_inst (img, Y_LBU_OP, 1,
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
 #endif
-		  r_sh_type_inst (img, Y_SLL_OP, std::get<int>($2), std::get<int>($2), 8);
-		  r_type_inst (img, Y_OR_OP, std::get<int>($2), std::get<int>($2), 1);
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  r_sh_type_inst (img, Y_SLL_OP, $2.i, $2.i, 8);
+		  r_type_inst (img, Y_OR_OP, $2.i, $2.i, 1);
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 
@@ -734,29 +736,29 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	STORE_OPS	SRC1	ADDRESS
 		{
-		  i_type_inst (img, std::get<int>($1) == Y_SD_POP ? Y_SW_OP : std::get<int>($1),
-			       std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
-		  if (std::get<int>($1) == Y_SD_POP)
-		    i_type_inst_free (img, Y_SW_OP, std::get<int>($2) + 1,
-				      addr_expr_reg (std::get<addr_expr *>($3)),
-				      incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+		  i_type_inst (img, $1.i == Y_SD_POP ? Y_SW_OP : $1.i,
+			       $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
+		  if ($1.i == Y_SD_POP)
+		    i_type_inst_free (img, Y_SW_OP, $2.i + 1,
+				      addr_expr_reg ((addr_expr *)$3.p),
+				      incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 							4));
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 
 	|	STOREC_OPS	COP_REG	ADDRESS
 		{
 		  i_type_inst (img,
-		  		   std::get<int>($1),
-			       std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  		   $1.i,
+			       $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 
@@ -764,63 +766,63 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 		{
 #ifdef SPIM_BIGENDIAN
 		  i_type_inst (img,
-		  		   Y_SWL_OP, std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
-		  i_type_inst_free (img, Y_SWR_OP, std::get<int>($2),
-				    addr_expr_reg (std::get<addr_expr *>($3)),
-				    incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+		  		   Y_SWL_OP, $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
+		  i_type_inst_free (img, Y_SWR_OP, $2.i,
+				    addr_expr_reg ((addr_expr *)$3.p),
+				    incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 						      3));
 #else
-		  i_type_inst_free (img, Y_SWL_OP, std::get<int>($2),
-				    addr_expr_reg (std::get<addr_expr *>($3)),
-				    incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+		  i_type_inst_free (img, Y_SWL_OP, $2.i,
+				    addr_expr_reg ((addr_expr *)$3.p),
+				    incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 						      3));
 		  i_type_inst (img,
-		  		   Y_SWR_OP, std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
+		  		   Y_SWR_OP, $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
 #endif
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 
 	|	Y_USH_POP	SRC1	ADDRESS
 		{
 		  i_type_inst (img,
-		  		   Y_SB_OP, std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
+		  		   Y_SB_OP, $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
 
 		  /* ROL SRC, SRC, 8 */
-		  r_sh_type_inst (img, Y_SLL_OP, 1, std::get<int>($2), 24);
-		  r_sh_type_inst (img, Y_SRL_OP, std::get<int>($2), std::get<int>($2), 8);
-		  r_type_inst (img, Y_OR_OP, std::get<int>($2), std::get<int>($2), 1);
+		  r_sh_type_inst (img, Y_SLL_OP, 1, $2.i, 24);
+		  r_sh_type_inst (img, Y_SRL_OP, $2.i, $2.i, 8);
+		  r_type_inst (img, Y_OR_OP, $2.i, $2.i, 1);
 
-		  i_type_inst_free (img, Y_SB_OP, std::get<int>($2),
-				    addr_expr_reg (std::get<addr_expr *>($3)),
-				    incr_expr_offset (img, addr_expr_imm (std::get<addr_expr *>($3)),
+		  i_type_inst_free (img, Y_SB_OP, $2.i,
+				    addr_expr_reg ((addr_expr *)$3.p),
+				    incr_expr_offset (img, addr_expr_imm ((addr_expr *)$3.p),
 						      1));
 		  /* ROR SRC, SRC, 8 */
-		  r_sh_type_inst (img, Y_SRL_OP, 1, std::get<int>($2), 24);
-		  r_sh_type_inst (img, Y_SLL_OP, std::get<int>($2), std::get<int>($2), 8);
-		  r_type_inst (img, Y_OR_OP, std::get<int>($2), std::get<int>($2), 1);
+		  r_sh_type_inst (img, Y_SRL_OP, 1, $2.i, 24);
+		  r_sh_type_inst (img, Y_SLL_OP, $2.i, $2.i, 8);
+		  r_type_inst (img, Y_OR_OP, $2.i, $2.i, 1);
 
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 
 	|	STOREFP_OPS	F_SRC1	ADDRESS
 		{
 		  i_type_inst (img,
-		  		   std::get<int>($1),
-			       std::get<int>($2),
-			       addr_expr_reg (std::get<addr_expr *>($3)),
-			       addr_expr_imm (std::get<addr_expr *>($3)));
-		  free ((std::get<addr_expr *>($3))->imm);
-		  free (std::get<addr_expr *>($3));
+		  		   $1.i,
+			       $2.i,
+			       addr_expr_reg ((addr_expr *)$3.p),
+			       addr_expr_imm ((addr_expr *)$3.p));
+		  free (((addr_expr *)$3.p)->imm);
+		  free ((addr_expr *)$3.p);
 		}
 
 
@@ -832,7 +834,7 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	SYS_OPS
 		{
-		  r_type_inst (img, std::get<int>($1), 0, 0, 0);
+		  r_type_inst (img, $1.i, 0, 0, 0);
 		}
 
 
@@ -844,32 +846,32 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	CACHE_OPS	Y_INT	ADDRESS
 		{
-		  i_type_inst_free (img, std::get<int>($1), std::get<int>($2), 0, std::get<imm_expr *>($3));
+		  i_type_inst_free (img, $1.i, $2.i, 0, (imm_expr *)$3.p);
 		}
 
 
 	|	TLB_OPS
 		{
-		  r_type_inst (img, std::get<int>($1), 0, 0, 0);
+		  r_type_inst (img, $1.i, 0, 0, 0);
 		}
 
 
 	|	Y_SYNC_OP
 		{
-		  r_type_inst (img, std::get<int>($1), 0, 0, 0);
+		  r_type_inst (img, $1.i, 0, 0, 0);
 		}
 
 	|	Y_SYNC_OP	Y_INT
 		{
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), 0, 0);
+		  r_type_inst (img, $1.i, $2.i, 0, 0);
 		}
 
 
 	|	Y_BREAK_OP	Y_INT
 		{
-		  if (std::get<int>($2) == 1)
+		  if ($2.i == 1)
 		    yyerror (img, "Breakpoint 1 is reserved for debugger");
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), 0, 0);
+		  r_type_inst (img, $1.i, $2.i, 0, 0);
 		}
 
 
@@ -887,41 +889,41 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	Y_ABS_POP	DEST	SRC1
 		{
-		  if (std::get<int>($2) != std::get<int>($3))
-		    r_type_inst (img, Y_ADDU_OP, std::get<int>($2), 0, std::get<int>($3));
+		  if ($2.i != $3.i)
+		    r_type_inst (img, Y_ADDU_OP, $2.i, 0, $3.i);
 
-		  i_type_inst_free (img, Y_BGEZ_OP, 0, std::get<int>($3), branch_offset (img, 2));
-		  r_type_inst (img, Y_SUB_OP, std::get<int>($2), 0, std::get<int>($3));
+		  i_type_inst_free (img, Y_BGEZ_OP, 0, $3.i, branch_offset (img, 2));
+		  r_type_inst (img, Y_SUB_OP, $2.i, 0, $3.i);
 		}
 
 
 	|	Y_NEG_POP	DEST	SRC1
 		{
-		  r_type_inst (img, Y_SUB_OP, std::get<int>($2), 0, std::get<int>($3));
+		  r_type_inst (img, Y_SUB_OP, $2.i, 0, $3.i);
 		}
 
 
 	|	Y_NEGU_POP	DEST	SRC1
 		{
-		  r_type_inst (img, Y_SUBU_OP, std::get<int>($2), 0, std::get<int>($3));
+		  r_type_inst (img, Y_SUBU_OP, $2.i, 0, $3.i);
 		}
 
 
 	|	Y_NOT_POP	DEST	SRC1
 		{
-		  r_type_inst (img, Y_NOR_OP, std::get<int>($2), std::get<int>($3), 0);
+		  r_type_inst (img, Y_NOR_OP, $2.i, $3.i, 0);
 		}
 
 
 	|	Y_MOVE_POP	DEST	SRC1
 		{
-		  r_type_inst (img, Y_ADDU_OP, std::get<int>($2), 0, std::get<int>($3));
+		  r_type_inst (img, Y_ADDU_OP, $2.i, 0, $3.i);
 		}
 
 
 	|	NULLARY_OPS
 		{
-		  r_type_inst (img, std::get<int>($1), 0, 0, 0);
+		  r_type_inst (img, $1.i, 0, 0, 0);
 		}
 
 
@@ -934,7 +936,7 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 	|	COUNT_LEADING_OPS DEST	SRC1
 		{
 		  /* RT must be equal to RD */
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($2));
+		  r_type_inst (img, $1.i, $2.i, $3.i, $2.i);
 		}
 
 
@@ -946,70 +948,70 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	BINARYI_OPS	DEST	SRC1	SRC2
 		{
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_type_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	BINARYI_OPS	DEST	SRC1	IMM32
 		{
-		  i_type_inst_free (img, op_to_imm_op (img, std::get<int>($1)), std::get<int>($2), std::get<int>($3),
-				    std::get<imm_expr *>($4));
+		  i_type_inst_free (img, op_to_imm_op (img, $1.i), $2.i, $3.i,
+				    (imm_expr *)$4.p);
 		}
 
 	|	BINARYI_OPS	DEST	IMM32
 		{
-		  i_type_inst_free (img, op_to_imm_op (img, std::get<int>($1)), std::get<int>($2), std::get<int>($2),
-				    std::get<imm_expr *>($3));
+		  i_type_inst_free (img, op_to_imm_op (img, $1.i), $2.i, $2.i,
+				    (imm_expr *)$3.p);
 		}
 
 
 	|	BINARYIR_OPS	DEST	SRC1	SRC2
 		{
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($4), std::get<int>($3));
+		  r_type_inst (img, $1.i, $2.i, $4.i, $3.i);
 		}
 
 	|	BINARYIR_OPS	DEST	SRC1	Y_INT
 		{
-		  r_sh_type_inst (img, op_to_imm_op (img, std::get<int>($1)), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_sh_type_inst (img, op_to_imm_op (img, $1.i), $2.i, $3.i, $4.i);
 		}
 
 	|	BINARYIR_OPS	DEST	Y_INT
 		{
-		  r_sh_type_inst (img, op_to_imm_op (img, std::get<int>($1)), std::get<int>($2), std::get<int>($2), std::get<int>($3));
+		  r_sh_type_inst (img, op_to_imm_op (img, $1.i), $2.i, $2.i, $3.i);
 		}
 
 
 	|	BINARY_ARITHI_OPS DEST	SRC1	IMM16
 		{
-		  i_type_inst_free (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<imm_expr *>($4));
+		  i_type_inst_free (img, $1.i, $2.i, $3.i, (imm_expr *)$4.p);
 		}
 
 	|	BINARY_ARITHI_OPS DEST	IMM16
 		{
-		  i_type_inst_free (img, std::get<int>($1), std::get<int>($2), std::get<int>($2), std::get<imm_expr *>($3));
+		  i_type_inst_free (img, $1.i, $2.i, $2.i, (imm_expr *)$3.p);
 		}
 
 
 	|	BINARY_LOGICALI_OPS DEST	SRC1	UIMM16
 		{
-		  i_type_inst_free (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<imm_expr *>($4));
+		  i_type_inst_free (img, $1.i, $2.i, $3.i, (imm_expr *)$4.p);
 		}
 
 	|	BINARY_LOGICALI_OPS DEST	UIMM16
 		{
-		  i_type_inst_free (img, std::get<int>($1), std::get<int>($2), std::get<int>($2), std::get<imm_expr *>($3));
+		  i_type_inst_free (img, $1.i, $2.i, $2.i, (imm_expr *)$3.p);
 		}
 
 
 	|	SHIFT_OPS	DEST	SRC1	Y_INT
 		{
-		  if ((std::get<int>($4) < 0) || (31 < std::get<int>($4)))
+		  if (($4.i < 0) || (31 < $4.i))
 		    yywarn (img, "Shift distance can only be in the range 0..31");
-		  r_sh_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_sh_type_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	SHIFT_OPS	DEST	SRC1	SRC2
 		{
-		  r_type_inst (img, imm_op_to_op (img, std::get<int>($1)), std::get<int>($2), std::get<int>($4), std::get<int>($3));
+		  r_type_inst (img, imm_op_to_op (img, $1.i), $2.i, $4.i, $3.i);
 		}
 
 
@@ -1026,7 +1028,7 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	BINARY_OPS	DEST	SRC1	SRC2
 		{
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_type_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	BINARY_OPS	DEST	SRC1	IMM32
@@ -1035,35 +1037,35 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 		    yyerror (img, "Immediate form not allowed in bare machine");
 		  else
 		    {
-		      if (!is_zero_imm (std::get<imm_expr *>($4)))
+		      if (!is_zero_imm ((imm_expr *)$4.p))
 			/* Use $at */
-			i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($4));
+			i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$4.p);
 		      r_type_inst (img,
-			  	   std::get<int>($1),
-				   std::get<int>($2),
-				   std::get<int>($3),
-				   (is_zero_imm (std::get<imm_expr *>($4)) ? 0 : 1));
+			  	   $1.i,
+				   $2.i,
+				   $3.i,
+				   (is_zero_imm ((imm_expr *)$4.p) ? 0 : 1));
 		    }
-		  free (std::get<imm_expr *>($4));
+		  free ((imm_expr *)$4.p);
 		}
 
 	|	BINARY_OPS	DEST	IMM32
 		{
-		  check_uimm_range (img, std::get<imm_expr *>($3), UIMM_MIN, UIMM_MAX);
+		  check_uimm_range (img, (imm_expr *)$3.p, UIMM_MIN, UIMM_MAX);
 		  if (bare_machine && !accept_pseudo_insts)
 		    yyerror (img, "Immediate form not allowed in bare machine");
 		  else
 		    {
-		      if (!is_zero_imm (std::get<imm_expr *>($3)))
+		      if (!is_zero_imm ((imm_expr *)$3.p))
 			/* Use $at */
-			i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($3));
+			i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$3.p);
 		      r_type_inst (img,
-				   std::get<int>($1),
-				   std::get<int>($2),
-				   std::get<int>($2),
-				   (is_zero_imm (std::get<imm_expr *>($3)) ? 0 : 1));
+				   $1.i,
+				   $2.i,
+				   $2.i,
+				   (is_zero_imm ((imm_expr *)$3.p) ? 0 : 1));
 		    }
-		  free (std::get<imm_expr *>($3));
+		  free ((imm_expr *)$3.p);
 		}
 
 
@@ -1075,151 +1077,151 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	SUB_OPS		DEST	SRC1	SRC2
 		{
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_type_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	SUB_OPS		DEST	SRC1	IMM32
 		{
-		  int val = eval_imm_expr (img, std::get<imm_expr *>($4));
+		  int val = eval_imm_expr (img, (imm_expr *)$4.p);
 
 		  if (bare_machine && !accept_pseudo_insts)
 		    yyerror (img, "Immediate form not allowed in bare machine");
 		  else {
             imm_expr *expr = make_imm_expr (img, -val, NULL, false);
-		    i_type_inst (img, std::get<int>($1) == Y_SUB_OP ? Y_ADDI_OP
-				 : std::get<int>($1) == Y_SUBU_OP ? Y_ADDIU_OP
+		    i_type_inst (img, $1.i == Y_SUB_OP ? Y_ADDI_OP
+				 : $1.i == Y_SUBU_OP ? Y_ADDIU_OP
 				 : (fatal_error (img, "Bad SUB_OP\n"), 0),
-				 std::get<int>($2),
-				 std::get<int>($3),
+				 $2.i,
+				 $3.i,
 				 expr);
             free(expr);
           }
-		  free (std::get<imm_expr *>($4));
+		  free ((imm_expr *)$4.p);
 		}
 
 	|	SUB_OPS		DEST	IMM32
 		{
-		  int val = eval_imm_expr (img, std::get<imm_expr *>($3));
+		  int val = eval_imm_expr (img, (imm_expr *)$3.p);
 
 		  if (bare_machine && !accept_pseudo_insts)
 		    yyerror (img, "Immediate form not allowed in bare machine");
 		  else
-		    i_type_inst_free (img, std::get<int>($1) == Y_SUB_OP ? Y_ADDI_OP
-				 : std::get<int>($1) == Y_SUBU_OP ? Y_ADDIU_OP
+		    i_type_inst_free (img, $1.i == Y_SUB_OP ? Y_ADDI_OP
+				 : $1.i == Y_SUBU_OP ? Y_ADDIU_OP
 				 : (fatal_error (img, "Bad SUB_OP\n"), 0),
-				 std::get<int>($2),
-				 std::get<int>($2),
+				 $2.i,
+				 $2.i,
 				 make_imm_expr (img, -val, NULL, false));
-		  free (std::get<imm_expr *>($3));
+		  free ((imm_expr *)$3.p);
 		}
 
 
 	|	DIV_POPS	DEST	SRC1
 		{
 		  /* The hardware divide operation (ignore 1st arg) */
-		  if (std::get<int>($1) != Y_DIV_OP && std::get<int>($1) != Y_DIVU_OP)
+		  if ($1.i != Y_DIV_OP && $1.i != Y_DIVU_OP)
 		    yyerror (img, "REM requires 3 arguments");
 		  else
-		    r_type_inst (img, std::get<int>($1), 0, std::get<int>($2), std::get<int>($3));
+		    r_type_inst (img, $1.i, 0, $2.i, $3.i);
 		}
 
 	|	DIV_POPS	DEST	SRC1	SRC2
 		{
 		  /* Pseudo divide operations */
-		  div_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4), 0);
+		  div_inst (img, $1.i, $2.i, $3.i, $4.i, 0);
 		}
 
 	|	DIV_POPS	DEST	SRC1	IMM32
 		{
-		  if (is_zero_imm (std::get<imm_expr *>($4)))
+		  if (is_zero_imm ((imm_expr *)$4.p))
 		    yyerror (img, "Divide by zero");
 		  else
 		    {
 		      /* Use $at */
-		      i_type_inst_free (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($4));
-		      div_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), 1, 1);
+		      i_type_inst_free (img, Y_ORI_OP, 1, 0, (imm_expr *)$4.p);
+		      div_inst (img, $1.i, $2.i, $3.i, 1, 1);
 		    }
 		}
 
 
 	|	MUL_POPS	DEST	SRC1	SRC2
 		{
-		  mult_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  mult_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	MUL_POPS	DEST	SRC1	IMM32
 		{
-		  if (is_zero_imm (std::get<imm_expr *>($4)))
+		  if (is_zero_imm ((imm_expr *)$4.p))
 		    /* Optimize: n * 0 == 0 */
-		    i_type_inst_free (img, Y_ORI_OP, std::get<int>($2), 0, std::get<imm_expr *>($4));
+		    i_type_inst_free (img, Y_ORI_OP, $2.i, 0, (imm_expr *)$4.p);
 		  else
 		    {
 		      /* Use $at */
-		      i_type_inst_free (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($4));
-		      mult_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), 1);
+		      i_type_inst_free (img, Y_ORI_OP, 1, 0, (imm_expr *)$4.p);
+		      mult_inst (img, $1.i, $2.i, $3.i, 1);
 		    }
 		}
 
 
 	|	MULT_OPS	SRC1	SRC2
 		{
-		  r_type_inst (img, std::get<int>($1), 0, std::get<int>($2), std::get<int>($3));
+		  r_type_inst (img, $1.i, 0, $2.i, $3.i);
 		}
 
 
 	|	MULT_OPS3	DEST	SRC1	SRC2
 		{
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_type_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	MULT_OPS3	DEST	SRC1	IMM32
 		{
 		  /* Special case, for backward compatibility with pseudo-op
 		     MULT instruction */
-		  i_type_inst_free (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($4)); /* Use $at */
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), 1);
+		  i_type_inst_free (img, Y_ORI_OP, 1, 0, (imm_expr *)$4.p); /* Use $at */
+		  r_type_inst (img, $1.i, $2.i, $3.i, 1);
 		}
 
 
 	|	Y_ROR_POP	DEST	SRC1	SRC2
 		{
-		  r_type_inst (img, Y_SUBU_OP, 1, 0, std::get<int>($4));
-		  r_type_inst (img, Y_SLLV_OP, 1, 1, std::get<int>($3));
-		  r_type_inst (img, Y_SRLV_OP, std::get<int>($2), std::get<int>($4), std::get<int>($3));
-		  r_type_inst (img, Y_OR_OP, std::get<int>($2), std::get<int>($2), 1);
+		  r_type_inst (img, Y_SUBU_OP, 1, 0, $4.i);
+		  r_type_inst (img, Y_SLLV_OP, 1, 1, $3.i);
+		  r_type_inst (img, Y_SRLV_OP, $2.i, $4.i, $3.i);
+		  r_type_inst (img, Y_OR_OP, $2.i, $2.i, 1);
 		}
 
 
 	|	Y_ROL_POP	DEST	SRC1	SRC2
 		{
-		  r_type_inst (img, Y_SUBU_OP, 1, 0, std::get<int>($4));
-		  r_type_inst (img, Y_SRLV_OP, 1, 1, std::get<int>($3));
-		  r_type_inst (img, Y_SLLV_OP, std::get<int>($2), std::get<int>($4), std::get<int>($3));
-		  r_type_inst (img, Y_OR_OP, std::get<int>($2), std::get<int>($2), 1);
+		  r_type_inst (img, Y_SUBU_OP, 1, 0, $4.i);
+		  r_type_inst (img, Y_SRLV_OP, 1, 1, $3.i);
+		  r_type_inst (img, Y_SLLV_OP, $2.i, $4.i, $3.i);
+		  r_type_inst (img, Y_OR_OP, $2.i, $2.i, 1);
 		}
 
 
 	|	Y_ROR_POP	DEST	SRC1	IMM32
 		{
-		  long dist = eval_imm_expr (img, std::get<imm_expr *>($4));
+		  long dist = eval_imm_expr (img, (imm_expr *)$4.p);
 
-		  check_imm_range (img, std::get<imm_expr *>($4), 0, 31);
-		  r_sh_type_inst (img, Y_SLL_OP, 1, std::get<int>($3), -dist);
-		  r_sh_type_inst (img, Y_SRL_OP, std::get<int>($2), std::get<int>($3), dist);
-		  r_type_inst (img, Y_OR_OP, std::get<int>($2), std::get<int>($2), 1);
-		  free (std::get<imm_expr *>($4));
+		  check_imm_range (img, (imm_expr *)$4.p, 0, 31);
+		  r_sh_type_inst (img, Y_SLL_OP, 1, $3.i, -dist);
+		  r_sh_type_inst (img, Y_SRL_OP, $2.i, $3.i, dist);
+		  r_type_inst (img, Y_OR_OP, $2.i, $2.i, 1);
+		  free ((imm_expr *)$4.p);
 		}
 
 
 	|	Y_ROL_POP	DEST	SRC1	IMM32
 		{
-		  long dist = eval_imm_expr (img, std::get<imm_expr *>($4));
+		  long dist = eval_imm_expr (img, (imm_expr *)$4.p);
 
-		  check_imm_range (img, std::get<imm_expr *>($4), 0, 31);
-		  r_sh_type_inst (img, Y_SRL_OP, 1, std::get<int>($3), -dist);
-		  r_sh_type_inst (img, Y_SLL_OP, std::get<int>($2), std::get<int>($3), dist);
-		  r_type_inst (img, Y_OR_OP, std::get<int>($2), std::get<int>($2), 1);
-		  free (std::get<imm_expr *>($4));
+		  check_imm_range (img, (imm_expr *)$4.p, 0, 31);
+		  r_sh_type_inst (img, Y_SRL_OP, 1, $3.i, -dist);
+		  r_sh_type_inst (img, Y_SLL_OP, $2.i, $3.i, dist);
+		  r_type_inst (img, Y_OR_OP, $2.i, $2.i, 1);
+		  free ((imm_expr *)$4.p);
 		}
 
 
@@ -1231,110 +1233,110 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	SET_LE_POPS	DEST	SRC1	SRC2
 		{
-		  set_le_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  set_le_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	SET_LE_POPS	DEST	SRC1	IMM32
 		{
-		  if (!is_zero_imm (std::get<imm_expr *>($4)))
+		  if (!is_zero_imm ((imm_expr *)$4.p))
 		    /* Use $at */
-		    i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($4));
-		  set_le_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3),
-			       (is_zero_imm (std::get<imm_expr *>($4)) ? 0 : 1));
-		  free (std::get<imm_expr *>($4));
+		    i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$4.p);
+		  set_le_inst (img, $1.i, $2.i, $3.i,
+			       (is_zero_imm ((imm_expr *)$4.p) ? 0 : 1));
+		  free ((imm_expr *)$4.p);
 		}
 
 
 	|	SET_GT_POPS	DEST	SRC1	SRC2
 		{
-		  set_gt_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  set_gt_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	SET_GT_POPS	DEST	SRC1	IMM32
 		{
-		  if (!is_zero_imm (std::get<imm_expr *>($4)))
+		  if (!is_zero_imm ((imm_expr *)$4.p))
 		    /* Use $at */
-		    i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($4));
-		  set_gt_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3),
-			       (is_zero_imm (std::get<imm_expr *>($4)) ? 0 : 1));
-		  free (std::get<imm_expr *>($4));
+		    i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$4.p);
+		  set_gt_inst (img, $1.i, $2.i, $3.i,
+			       (is_zero_imm ((imm_expr *)$4.p) ? 0 : 1));
+		  free ((imm_expr *)$4.p);
 		}
 
 
 
 	|	SET_GE_POPS	DEST	SRC1	SRC2
 		{
-		  set_ge_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  set_ge_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	SET_GE_POPS	DEST	SRC1	IMM32
 		{
-		  if (!is_zero_imm (std::get<imm_expr *>($4)))
+		  if (!is_zero_imm ((imm_expr *)$4.p))
 		    /* Use $at */
-		    i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($4));
-		  set_ge_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3),
-			       (is_zero_imm (std::get<imm_expr *>($4)) ? 0 : 1));
-		  free (std::get<imm_expr *>($4));
+		    i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$4.p);
+		  set_ge_inst (img, $1.i, $2.i, $3.i,
+			       (is_zero_imm ((imm_expr *)$4.p) ? 0 : 1));
+		  free ((imm_expr *)$4.p);
 		}
 
 
 	|	SET_EQ_POPS	DEST	SRC1	SRC2
 		{
-		  set_eq_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  set_eq_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 	|	SET_EQ_POPS	DEST	SRC1	IMM32
 		{
-		  if (!is_zero_imm (std::get<imm_expr *>($4)))
+		  if (!is_zero_imm ((imm_expr *)$4.p))
 		    /* Use $at */
-		    i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($4));
-		  set_eq_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3),
-			       (is_zero_imm (std::get<imm_expr *>($4)) ? 0 : 1));
-		  free (std::get<imm_expr *>($4));
+		    i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$4.p);
+		  set_eq_inst (img, $1.i, $2.i, $3.i,
+			       (is_zero_imm ((imm_expr *)$4.p) ? 0 : 1));
+		  free ((imm_expr *)$4.p);
 		}
 
 
 	|	BR_COP_OPS	LABEL
 		{
 		  /* RS and RT fields contain information on test */
-                  int nd = opcode_is_nullified_branch (std::get<int>($1)) ? 1 : 0;
-                  int tf = opcode_is_true_branch (std::get<int>($1)) ? 1 : 0;
+                  int nd = opcode_is_nullified_branch ($1.i) ? 1 : 0;
+                  int tf = opcode_is_true_branch ($1.i) ? 1 : 0;
 		  i_type_inst_free (img,
-		  			std::get<int>($1),
+		  			$1.i,
 				    cc_to_rt (0, nd, tf),
-				    BIN_RS (std::get<int>($1)),
-				    std::get<imm_expr *>($2));
+				    BIN_RS ($1.i),
+				    (imm_expr *)$2.p);
 		}
 
 	|	BR_COP_OPS	CC_REG	LABEL
 		{
 		  /* RS and RT fields contain information on test */
-                  int nd = opcode_is_nullified_branch (std::get<int>($1)) ? 1 : 0;
-                  int tf = opcode_is_true_branch (std::get<int>($1)) ? 1 : 0;
+                  int nd = opcode_is_nullified_branch ($1.i) ? 1 : 0;
+                  int tf = opcode_is_true_branch ($1.i) ? 1 : 0;
 		  i_type_inst_free (img,
-		  			std::get<int>($1),
-				    cc_to_rt (std::get<int>($2), nd, tf),
-				    BIN_RS (std::get<int>($1)),
-				    std::get<imm_expr *>($3));
+		  			$1.i,
+				    cc_to_rt ($2.i, nd, tf),
+				    BIN_RS ($1.i),
+				    (imm_expr *)$3.p);
 		}
 
 
 	|	UNARY_BR_OPS	SRC1	LABEL
 		{
-		  i_type_inst_free (img, std::get<int>($1), 0, std::get<int>($2), std::get<imm_expr *>($3));
+		  i_type_inst_free (img, $1.i, 0, $2.i, (imm_expr *)$3.p);
 		}
 
 
 	|	UNARY_BR_POPS	SRC1	LABEL
 		{
-		  i_type_inst_free (img, std::get<int>($1) == Y_BEQZ_POP ? Y_BEQ_OP : Y_BNE_OP,
-			       0, std::get<int>($2), std::get<imm_expr *>($3));
+		  i_type_inst_free (img, $1.i == Y_BEQZ_POP ? Y_BEQ_OP : Y_BNE_OP,
+			       0, $2.i, (imm_expr *)$3.p);
 		}
 
 
 	|	BINARY_BR_OPS	SRC1	SRC2	LABEL
 		{
-		  i_type_inst_free (img, std::get<int>($1), std::get<int>($3), std::get<int>($2), std::get<imm_expr *>($4));
+		  i_type_inst_free (img, $1.i, $3.i, $2.i, (imm_expr *)$4.p);
 		}
 
 	|	BINARY_BR_OPS	SRC1	BR_IMM32	LABEL
@@ -1343,164 +1345,164 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 		    yyerror (img, "Immediate form not allowed in bare machine");
 		  else
 		    {
-		      if (is_zero_imm (std::get<imm_expr *>($3)))
-			i_type_inst (img,std::get<int>($1), std::get<int>($2),
-				     (is_zero_imm (std::get<imm_expr *>($3)) ? 0 : 1),
-				     std::get<imm_expr *>($4));
+		      if (is_zero_imm ((imm_expr *)$3.p))
+			i_type_inst (img,$1.i, $2.i,
+				     (is_zero_imm ((imm_expr *)$3.p) ? 0 : 1),
+				     (imm_expr *)$4.p);
 		      else
 			{
 			  /* Use $at */
-			  i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($3));
-			  i_type_inst (img, std::get<int>($1), std::get<int>($2),
-				       (is_zero_imm (std::get<imm_expr *>($3)) ? 0 : 1),
-				       std::get<imm_expr *>($4));
+			  i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$3.p);
+			  i_type_inst (img, $1.i, $2.i,
+				       (is_zero_imm ((imm_expr *)$3.p) ? 0 : 1),
+				       (imm_expr *)$4.p);
 			}
 		    }
-		  free (std::get<imm_expr *>($3));
-		  free (std::get<imm_expr *>($4));
+		  free ((imm_expr *)$3.p);
+		  free ((imm_expr *)$4.p);
 		}
 
 
 	|	BR_GT_POPS	SRC1	SRC2	LABEL
 		{
-		  r_type_inst (img, std::get<int>($1) == Y_BGT_POP ? Y_SLT_OP : Y_SLTU_OP,
-			       1, std::get<int>($3), std::get<int>($2)); /* Use $at */
-		  i_type_inst_free (img, Y_BNE_OP, 0, 1, std::get<imm_expr *>($4));
+		  r_type_inst (img, $1.i == Y_BGT_POP ? Y_SLT_OP : Y_SLTU_OP,
+			       1, $3.i, $2.i); /* Use $at */
+		  i_type_inst_free (img, Y_BNE_OP, 0, 1, (imm_expr *)$4.p);
 		}
 
 	|	BR_GT_POPS	SRC1	BR_IMM32	LABEL
 		{
-		  if (std::get<int>($1) == Y_BGT_POP)
+		  if ($1.i == Y_BGT_POP)
 		    {
 		      /* Use $at */
-		      i_type_inst_free (img, Y_SLTI_OP, 1, std::get<int>($2),
-					incr_expr_offset (img, std::get<imm_expr *>($3), 1));
-		      i_type_inst (img, Y_BEQ_OP, 0, 1, std::get<imm_expr *>($4));
+		      i_type_inst_free (img, Y_SLTI_OP, 1, $2.i,
+					incr_expr_offset (img, (imm_expr *)$3.p, 1));
+		      i_type_inst (img, Y_BEQ_OP, 0, 1, (imm_expr *)$4.p);
 		    }
 		  else
 		    {
 		      /* Use $at */
 		      /* Can't add 1 to immediate since 0xffffffff+1 = 0 < 1 */
-		      i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($3));
-		      i_type_inst_free (img, Y_BEQ_OP, std::get<int>($2), 1, branch_offset (img, 3));
-		      r_type_inst (img, Y_SLTU_OP, 1, std::get<int>($2), 1);
-		      i_type_inst (img, Y_BEQ_OP, 0, 1, std::get<imm_expr *>($4));
+		      i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$3.p);
+		      i_type_inst_free (img, Y_BEQ_OP, $2.i, 1, branch_offset (img, 3));
+		      r_type_inst (img, Y_SLTU_OP, 1, $2.i, 1);
+		      i_type_inst (img, Y_BEQ_OP, 0, 1, (imm_expr *)$4.p);
 		    }
-		  free (std::get<imm_expr *>($3));
-		  free (std::get<imm_expr *>($4));
+		  free ((imm_expr *)$3.p);
+		  free ((imm_expr *)$4.p);
 		}
 
 
 	|	BR_GE_POPS	SRC1	SRC2	LABEL
 		{
-		  r_type_inst (img, std::get<int>($1) == Y_BGE_POP ? Y_SLT_OP : Y_SLTU_OP,
-			       1, std::get<int>($2), std::get<int>($3)); /* Use $at */
-		  i_type_inst_free (img, Y_BEQ_OP, 0, 1, std::get<imm_expr *>($4));
+		  r_type_inst (img, $1.i == Y_BGE_POP ? Y_SLT_OP : Y_SLTU_OP,
+			       1, $2.i, $3.i); /* Use $at */
+		  i_type_inst_free (img, Y_BEQ_OP, 0, 1, (imm_expr *)$4.p);
 		}
 
 	|	BR_GE_POPS	SRC1	BR_IMM32	LABEL
 		{
-		  i_type_inst (img, std::get<int>($1) == Y_BGE_POP ? Y_SLTI_OP : Y_SLTIU_OP,
-			       1, std::get<int>($2), std::get<imm_expr *>($3)); /* Use $at */
-		  i_type_inst_free (img, Y_BEQ_OP, 0, 1, std::get<imm_expr *>($4));
-		  free (std::get<imm_expr *>($3));
+		  i_type_inst (img, $1.i == Y_BGE_POP ? Y_SLTI_OP : Y_SLTIU_OP,
+			       1, $2.i, (imm_expr *)$3.p); /* Use $at */
+		  i_type_inst_free (img, Y_BEQ_OP, 0, 1, (imm_expr *)$4.p);
+		  free ((imm_expr *)$3.p);
 		}
 
 
 	|	BR_LT_POPS	SRC1	SRC2	LABEL
 		{
-		  r_type_inst (img, std::get<int>($1) == Y_BLT_POP ? Y_SLT_OP : Y_SLTU_OP,
-			       1, std::get<int>($2), std::get<int>($3)); /* Use $at */
-		  i_type_inst_free (img, Y_BNE_OP, 0, 1, std::get<imm_expr *>($4));
+		  r_type_inst (img, $1.i == Y_BLT_POP ? Y_SLT_OP : Y_SLTU_OP,
+			       1, $2.i, $3.i); /* Use $at */
+		  i_type_inst_free (img, Y_BNE_OP, 0, 1, (imm_expr *)$4.p);
 		}
 
 	|	BR_LT_POPS	SRC1	BR_IMM32	LABEL
 		{
-		  i_type_inst (img, std::get<int>($1) == Y_BLT_POP ? Y_SLTI_OP : Y_SLTIU_OP,
-			       1, std::get<int>($2), std::get<imm_expr *>($3)); /* Use $at */
-		  i_type_inst_free (img, Y_BNE_OP, 0, 1, std::get<imm_expr *>($4));
-		  free (std::get<imm_expr *>($3));
+		  i_type_inst (img, $1.i == Y_BLT_POP ? Y_SLTI_OP : Y_SLTIU_OP,
+			       1, $2.i, (imm_expr *)$3.p); /* Use $at */
+		  i_type_inst_free (img, Y_BNE_OP, 0, 1, (imm_expr *)$4.p);
+		  free ((imm_expr *)$3.p);
 		}
 
 
 	|	BR_LE_POPS	SRC1	SRC2	LABEL
 		{
-		  r_type_inst (img, std::get<int>($1) == Y_BLE_POP ? Y_SLT_OP : Y_SLTU_OP,
-			       1, std::get<int>($3), std::get<int>($2)); /* Use $at */
-		  i_type_inst_free (img, Y_BEQ_OP, 0, 1, std::get<imm_expr *>($4));
+		  r_type_inst (img, $1.i == Y_BLE_POP ? Y_SLT_OP : Y_SLTU_OP,
+			       1, $3.i, $2.i); /* Use $at */
+		  i_type_inst_free (img, Y_BEQ_OP, 0, 1, (imm_expr *)$4.p);
 		}
 
 	|	BR_LE_POPS	SRC1	BR_IMM32	LABEL
 		{
-		  if (std::get<int>($1) == Y_BLE_POP)
+		  if ($1.i == Y_BLE_POP)
 		    {
 		      /* Use $at */
-		      i_type_inst_free (img, Y_SLTI_OP, 1, std::get<int>($2),
-					incr_expr_offset (img, std::get<imm_expr *>($3), 1));
-		      i_type_inst (img, Y_BNE_OP, 0, 1, std::get<imm_expr *>($4));
+		      i_type_inst_free (img, Y_SLTI_OP, 1, $2.i,
+					incr_expr_offset (img, (imm_expr *)$3.p, 1));
+		      i_type_inst (img, Y_BNE_OP, 0, 1, (imm_expr *)$4.p);
 		    }
 		  else
 		    {
 		      /* Use $at */
 		      /* Can't add 1 to immediate since 0xffffffff+1 = 0 < 1 */
-		      i_type_inst (img, Y_ORI_OP, 1, 0, std::get<imm_expr *>($3));
-		      i_type_inst (img, Y_BEQ_OP, std::get<int>($2), 1, std::get<imm_expr *>($4));
-		      r_type_inst (img, Y_SLTU_OP, 1, std::get<int>($2), 1);
-		      i_type_inst (img, Y_BNE_OP, 0, 1, std::get<imm_expr *>($4));
+		      i_type_inst (img, Y_ORI_OP, 1, 0, (imm_expr *)$3.p);
+		      i_type_inst (img, Y_BEQ_OP, $2.i, 1, (imm_expr *)$4.p);
+		      r_type_inst (img, Y_SLTU_OP, 1, $2.i, 1);
+		      i_type_inst (img, Y_BNE_OP, 0, 1, (imm_expr *)$4.p);
 		    }
-		  free (std::get<imm_expr *>($3));
-		  free (std::get<imm_expr *>($4));
+		  free ((imm_expr *)$3.p);
+		  free ((imm_expr *)$4.p);
 		}
 
 
 	|	J_OPS		LABEL
 		{
-		  if ((std::get<int>($1) == Y_J_OP) || (std::get<int>($1) == Y_JR_OP))
-		    j_type_inst (img, Y_J_OP, std::get<imm_expr *>($2));
-		  else if ((std::get<int>($1) == Y_JAL_OP) || (std::get<int>($1) == Y_JALR_OP))
-		    j_type_inst (img, Y_JAL_OP, std::get<imm_expr *>($2));
-		  free (std::get<imm_expr *>($2));
+		  if (($1.i == Y_J_OP) || ($1.i == Y_JR_OP))
+		    j_type_inst (img, Y_J_OP, (imm_expr *)$2.p);
+		  else if (($1.i == Y_JAL_OP) || ($1.i == Y_JALR_OP))
+		    j_type_inst (img, Y_JAL_OP, (imm_expr *)$2.p);
+		  free ((imm_expr *)$2.p);
 		}
 
 	|	J_OPS		SRC1
 		{
-		  if ((std::get<int>($1) == Y_J_OP) || (std::get<int>($1) == Y_JR_OP))
-		    r_type_inst (img, Y_JR_OP, 0, std::get<int>($2), 0);
-		  else if ((std::get<int>($1) == Y_JAL_OP) || (std::get<int>($1) == Y_JALR_OP))
-		    r_type_inst (img, Y_JALR_OP, 31, std::get<int>($2), 0);
+		  if (($1.i == Y_J_OP) || ($1.i == Y_JR_OP))
+		    r_type_inst (img, Y_JR_OP, 0, $2.i, 0);
+		  else if (($1.i == Y_JAL_OP) || ($1.i == Y_JALR_OP))
+		    r_type_inst (img, Y_JALR_OP, 31, $2.i, 0);
 		}
 
 	|	J_OPS		DEST	SRC1
 		{
-		  if ((std::get<int>($1) == Y_J_OP) || (std::get<int>($1) == Y_JR_OP))
-		    r_type_inst (img, Y_JR_OP, 0, std::get<int>($3), 0);
-		  else if ((std::get<int>($1) == Y_JAL_OP) || (std::get<int>($1) == Y_JALR_OP))
-		    r_type_inst (img, Y_JALR_OP, std::get<int>($2), std::get<int>($3), 0);
+		  if (($1.i == Y_J_OP) || ($1.i == Y_JR_OP))
+		    r_type_inst (img, Y_JR_OP, 0, $3.i, 0);
+		  else if (($1.i == Y_JAL_OP) || ($1.i == Y_JALR_OP))
+		    r_type_inst (img, Y_JALR_OP, $2.i, $3.i, 0);
 		}
 
 
 	|	B_OPS		LABEL
 		{
-		  i_type_inst_free (img, (std::get<int>($1) == Y_BAL_POP ? Y_BGEZAL_OP : Y_BGEZ_OP),
-				    0, 0, std::get<imm_expr *>($2));
+		  i_type_inst_free (img, ($1.i == Y_BAL_POP ? Y_BGEZAL_OP : Y_BGEZ_OP),
+				    0, 0, (imm_expr *)$2.p);
 		}
 
 
 	|	BINARYI_TRAP_OPS	SRC1	IMM16
 		{
-		  i_type_inst_free (img, std::get<int>($1), 0, std::get<int>($2), std::get<imm_expr *>($3));
+		  i_type_inst_free (img, $1.i, 0, $2.i, (imm_expr *)$3.p);
 		}
 
 
 	|	BINARY_TRAP_OPS	SRC1	SRC2
 		{
-		  r_type_inst (img, std::get<int>($1), 0, std::get<int>($2), std::get<int>($3));
+		  r_type_inst (img, $1.i, 0, $2.i, $3.i);
 		}
 
 
 	|	FP_MOVE_OPS	F_DEST	F_SRC1
 		{
-		  r_co_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), 0);
+		  r_co_type_inst (img, $1.i, $2.i, $3.i, 0);
 		}
 
 
@@ -1512,23 +1514,23 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	MOVEC_OPS	DEST	SRC1	REG
 		{
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_type_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 
 	|	MOVECC_OPS	DEST	SRC1	Y_INT
 		{
                     r_type_inst (img,
-								 std::get<int>($1),
-                                 std::get<int>($2),
-                                 std::get<int>($3),
-                                 ((std::get<int>($4) & 0x7) << 2));
+								 $1.i,
+                                 $2.i,
+                                 $3.i,
+                                 (($4.i & 0x7) << 2));
 		}
 
 
 	|	FP_MOVEC_OPS	F_DEST	F_SRC1	REG
 		{
-		  r_co_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_co_type_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 
@@ -1540,13 +1542,13 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	FP_MOVECC_OPS	F_DEST	F_SRC1
 		{
-		  r_co_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), cc_to_rt (0, 0, 0));
+		  r_co_type_inst (img, $1.i, $2.i, $3.i, cc_to_rt (0, 0, 0));
 		}
 
 
 	|	FP_MOVECC_OPS	F_DEST	F_SRC1	CC_REG
 		{
-		  r_co_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), cc_to_rt (std::get<int>($4), 0, 0));
+		  r_co_type_inst (img, $1.i, $2.i, $3.i, cc_to_rt ($4.i, 0, 0));
 		}
 
 
@@ -1558,31 +1560,31 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	MOVE_FROM_HILO_OPS REG
 		{
-		  r_type_inst (img, std::get<int>($1), std::get<int>($2), 0, 0);
+		  r_type_inst (img, $1.i, $2.i, 0, 0);
 		}
 
 
 	|	MOVE_TO_HILO_OPS REG
 		{
-		  r_type_inst (img, std::get<int>($1), 0, std::get<int>($2), 0);
+		  r_type_inst (img, $1.i, 0, $2.i, 0);
 		}
 
 
 
 	|	MOVE_COP_OPS	REG	COP_REG
 		{
-		  if (std::get<int>($1) == Y_MFC1_D_POP)
+		  if ($1.i == Y_MFC1_D_POP)
 		    {
-		      r_co_type_inst (img, Y_MFC1_OP, 0, std::get<int>($3), std::get<int>($2));
-		      r_co_type_inst (img, Y_MFC1_OP, 0, std::get<int>($3) + 1, std::get<int>($2) + 1);
+		      r_co_type_inst (img, Y_MFC1_OP, 0, $3.i, $2.i);
+		      r_co_type_inst (img, Y_MFC1_OP, 0, $3.i + 1, $2.i + 1);
 		    }
-		  else if (std::get<int>($1) == Y_MTC1_D_POP)
+		  else if ($1.i == Y_MTC1_D_POP)
 		    {
-		      r_co_type_inst (img, Y_MTC1_OP, 0, std::get<int>($3), std::get<int>($2));
-		      r_co_type_inst (img, Y_MTC1_OP, 0, std::get<int>($3) + 1, std::get<int>($2) + 1);
+		      r_co_type_inst (img, Y_MTC1_OP, 0, $3.i, $2.i);
+		      r_co_type_inst (img, Y_MTC1_OP, 0, $3.i + 1, $2.i + 1);
 		    }
 		  else
-		    r_co_type_inst (img, std::get<int>($1), 0, std::get<int>($3), std::get<int>($2));
+		    r_co_type_inst (img, $1.i, 0, $3.i, $2.i);
 		}
 
 
@@ -1594,13 +1596,13 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	CTL_COP_OPS	REG	COP_REG
 		{
-		  r_co_type_inst (img, std::get<int>($1), 0, std::get<int>($3), std::get<int>($2));
+		  r_co_type_inst (img, $1.i, 0, $3.i, $2.i);
 		}
 
 
 	|	FP_UNARY_OPS	F_DEST	F_SRC2
 		{
-		  r_co_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), 0);
+		  r_co_type_inst (img, $1.i, $2.i, $3.i, 0);
 		}
 
 
@@ -1612,7 +1614,7 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	FP_BINARY_OPS	F_DEST	F_SRC1	F_SRC2
 		{
-		  r_co_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), std::get<int>($4));
+		  r_co_type_inst (img, $1.i, $2.i, $3.i, $4.i);
 		}
 
 
@@ -1630,13 +1632,13 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	FP_CMP_OPS	F_SRC1	F_SRC2
 		{
-		  r_cond_type_inst (img, std::get<int>($1), std::get<int>($2), std::get<int>($3), 0);
+		  r_cond_type_inst (img, $1.i, $2.i, $3.i, 0);
 		}
 
 
 	|	FP_CMP_OPS	CC_REG	F_SRC1	F_SRC2
 		{
-		  r_cond_type_inst (img, std::get<int>($1), std::get<int>($3), std::get<int>($4), std::get<int>($2));
+		  r_cond_type_inst (img, $1.i, $3.i, $4.i, $2.i);
 		}
 
 
@@ -1648,7 +1650,7 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 	|	Y_COP2_OP	IMM32
 		{
-		  i_type_inst_free (img, std::get<int>($1), 0, 0, std::get<imm_expr *>($2));
+		  i_type_inst_free (img, $1.i, 0, 0, (imm_expr *)$2.p);
 		}
 	;
 
@@ -1679,8 +1681,8 @@ LOADC_OPS:	Y_LDC2_OP
 
 LOADFP_OPS:	Y_LDC1_OP
 	|	Y_LWC1_OP
-	|	Y_L_D_POP { $$ = Y_LDC1_OP; }
-	|	Y_L_S_POP { $$ = Y_LWC1_OP; }
+	|	Y_L_D_POP { $$.i = Y_LDC1_OP; }
+	|	Y_L_S_POP { $$.i = Y_LWC1_OP; }
 	;
 
 LOADFP_INDEX_OPS:	Y_LDXC1_OP
@@ -1699,8 +1701,8 @@ STORE_OPS:	Y_SB_OP
 
 STOREC_OPS:	Y_SWC2_OP
 	|	Y_SDC2_OP
-	|	Y_S_D_POP { $$ = Y_SDC1_OP; }
-	|	Y_S_S_POP { $$ = Y_SWC1_OP; }
+	|	Y_S_D_POP { $$.i = Y_SDC1_OP; }
+	|	Y_S_S_POP { $$.i = Y_SWC1_OP; }
 	;
 
 STOREFP_OPS:	Y_SWC1_OP
@@ -2138,7 +2140,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 
 	|	Y_ALIGN_DIR	EXPR
 		{
-		  align_data (img, std::get<int>($2));
+		  align_data (img, $2.i);
 		}
 
 	|	Y_ASCII_DIR {null_term = false;}	STR_LST
@@ -2171,11 +2173,12 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 	|	Y_COMM_DIR	ID	EXPR
 		{
 		  align_data (img, 2);
-		  if (lookup_label (img, std::get<std::shared_ptr<char>>($2).get())->addr == 0)
+		  if (lookup_label (img, (char*)$2.p)->addr == 0)
 		  {
-		    (void)record_label (img, std::get<std::shared_ptr<char>>($2).get(), current_data_pc (img), 1);
+		    (void)record_label (img, (char*)$2.p, current_data_pc (img), 1);
+		    free ((char*)$2.p);
 		  }
-		  increment_data_pc (img, std::get<int>($3));
+		  increment_data_pc (img, $3.i);
 		}
 
 
@@ -2190,7 +2193,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 		  user_kernel_data_segment (img, false);
 		  data_dir = true; text_dir = false;
 		  enable_data_alignment (img);
-		  set_data_pc (img, std::get<int>($2));
+		  set_data_pc (img, $2.i);
 		}
 
 
@@ -2206,7 +2209,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
                     user_kernel_data_segment (img, true);
 		  data_dir = true; text_dir = false;
 		  enable_data_alignment (img);
-		  set_data_pc (img, std::get<int>($2));
+		  set_data_pc (img, $2.i);
 		}
 
 
@@ -2235,7 +2238,8 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 
 	|	Y_EXTERN_DIR	ID	EXPR
 		{
-		  extern_directive (img, std::get<std::shared_ptr<char>>($2).get(), std::get<int>($3));
+		  extern_directive (img, (char*)$2.p, $3.i);
+          free((char *) $2.p);
 		}
 
 
@@ -2267,7 +2271,8 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 
 	|	Y_GLOBAL_DIR	ID
 		{
-		  (void)make_label_global (img, std::get<std::shared_ptr<char>>($2).get());
+		  (void)make_label_global (img, (char*)$2.p);
+		  free ((char*)$2.p);
 		}
 
 
@@ -2286,15 +2291,17 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 	|	Y_LABEL_DIR	ID
 		{
 		  (void)record_label (img,
-		  			  std::get<std::shared_ptr<char>>($2).get(),
+		  			  (char*)$2.p,
 				      text_dir ? current_text_pc (img) : current_data_pc (img),
 				      1);
+		  free ((char*)$2.p);
 		}
 
 
 	|	Y_LCOMM_DIR	ID	EXPR
 		{
-		  lcomm_directive (img, std::get<std::shared_ptr<char>>($2).get(), std::get<int>($3));
+		  lcomm_directive (img, (char*)$2.p, $3.i);
+          free((char *) $2.p);
 		}
 
 
@@ -2328,7 +2335,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 		  user_kernel_data_segment (img, false);
 		  data_dir = true; text_dir = false;
 		  enable_data_alignment (img);
-		  set_data_pc (img, std::get<int>($2));
+		  set_data_pc (img, $2.i);
 		}
 
 
@@ -2344,25 +2351,26 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 		  user_kernel_data_segment (img, false);
 		  data_dir = true; text_dir = false;
 		  enable_data_alignment (img);
-		  set_data_pc (img, std::get<int>($2));
+		  set_data_pc (img, $2.i);
 		}
 
 
 	|	Y_SET_DIR	ID
 		{
-		  if (streq (std::get<std::shared_ptr<char>>($2).get(), "noat"))
+		  if (streq ((char*)$2.p, "noat"))
 		    noat_flag = true;
-		  else if (streq (std::get<std::shared_ptr<char>>($2).get(), "at"))
+		  else if (streq ((char*)$2.p, "at"))
 		    noat_flag = false;
+          free((char*) $2.p);
 		}
 
 
 	|	Y_SPACE_DIR	EXPR
 		{
 		  if (data_dir)
-		    increment_data_pc (img, std::get<int>($2));
+		    increment_data_pc (img, $2.i);
 		  else if (text_dir)
-		    increment_text_pc (img, std::get<int>($2));
+		    increment_text_pc (img, $2.i);
 		}
 
 
@@ -2384,7 +2392,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 		  user_kernel_text_segment (img, false);
 		  data_dir = false; text_dir = true;
 		  enable_data_alignment (img);
-		  set_text_pc (img, std::get<int>($2));
+		  set_text_pc (img, $2.i);
 		}
 
 
@@ -2400,7 +2408,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 		  user_kernel_text_segment (img, true);
 		  data_dir = false; text_dir = true;
 		  enable_data_alignment (img);
-		  set_text_pc (img, std::get<int>($2));
+		  set_text_pc (img, $2.i);
 		}
 
 
@@ -2424,52 +2432,59 @@ ADDRESS:	{only_id = 1;} ADDR {only_id = 0; $$ = $2;}
 
 ADDR:		'(' REGISTER ')'
 		{
-		  $$ = make_addr_expr (img, 0, NULL, std::get<int>($2));
+		  $$.p = make_addr_expr (img, 0, NULL, $2.i);
 		}
 
 	|	ABS_ADDR
 		{
-		  $$ = make_addr_expr (img, std::get<int>($1), NULL, 0);
+		  $$.p = make_addr_expr (img, $1.i, NULL, 0);
 		}
 
 	|	ABS_ADDR '(' REGISTER ')'
 		{
-		  $$ = make_addr_expr (img, std::get<int>($1), NULL, std::get<int>($3));
+		  $$.p = make_addr_expr (img, $1.i, NULL, $3.i);
 		}
 
 	|	Y_ID
 		{
-		  $$ = make_addr_expr (img, 0, std::get<std::shared_ptr<char>>($1).get(), 0);
+		  $$.p = make_addr_expr (img, 0, (char*)$1.p, 0);
+		  free ((char*)$1.p);
 		}
 
 	|	Y_ID '(' REGISTER ')'
 		{
-		  $$ = make_addr_expr (img, 0, std::get<std::shared_ptr<char>>($1).get(), std::get<int>($3));
+		  $$.p = make_addr_expr (img, 0, (char*)$1.p, $3.i);
+		  free ((char*)$1.p);
 		}
 
 	|	Y_ID '+' ABS_ADDR
 		{
-		  $$ = make_addr_expr (img, std::get<int>($3), std::get<std::shared_ptr<char>>($1).get(), 0);
+		  $$.p = make_addr_expr (img, $3.i, (char*)$1.p, 0);
+		  free ((char*)$1.p);
 		}
 
 	|	ABS_ADDR '+' ID
 		{
-		  $$ = make_addr_expr (img, std::get<int>($1), std::get<std::shared_ptr<char>>($3).get(), 0);
+		  $$.p = make_addr_expr (img, $1.i, (char*)$3.p, 0);
+          free((char *) $3.p);
 		}
 
 	|	Y_ID '-' ABS_ADDR
 		{
-		  $$ = make_addr_expr (img, - std::get<int>($3), std::get<std::shared_ptr<char>>($1).get(), 0);
+		  $$.p = make_addr_expr (img, - $3.i, (char*)$1.p, 0);
+		  free ((char*)$1.p);
 		}
 
 	|	Y_ID '+' ABS_ADDR '(' REGISTER ')'
 		{
-		  $$ = make_addr_expr (img, std::get<int>($3), std::get<std::shared_ptr<char>>($1).get(), std::get<int>($5));
+		  $$.p = make_addr_expr (img, $3.i, (char*)$1.p, $5.i);
+		  free ((char*)$1.p);
 		}
 
 	|	Y_ID '-' ABS_ADDR '(' REGISTER ')'
 		{
-		  $$ = make_addr_expr (img, - std::get<int>($3), std::get<std::shared_ptr<char>>($1).get(), std::get<int>($5));
+		  $$.p = make_addr_expr (img, - $3.i, (char*)$1.p, $5.i);
+		  free ((char*)$1.p);
 		}
 	;
 
@@ -2478,40 +2493,43 @@ BR_IMM32:	{only_id = 1;} IMM32 {only_id = 0; $$ = $2;}
 
 IMM16:	IMM32
 		{
-                  check_imm_range (img, std::get<imm_expr *>($1), IMM_MIN, IMM_MAX);
+                  check_imm_range (img, (imm_expr*)$1.p, IMM_MIN, IMM_MAX);
 		  $$ = $1;
 		}
 
 UIMM16:	IMM32
 		{
-                  check_uimm_range (img, std::get<imm_expr *>($1), UIMM_MIN, UIMM_MAX);
+                  check_uimm_range (img, (imm_expr*)$1.p, UIMM_MIN, UIMM_MAX);
 		  $$ = $1;
 		}
 
 
 IMM32:		ABS_ADDR
 		{
-		  $$ = make_imm_expr (img, std::get<int>($1), NULL, false);
+		  $$.p = make_imm_expr (img, $1.i, NULL, false);
 		}
 
 	|	'(' ABS_ADDR ')' '>' '>' Y_INT
 		{
-		  $$ = make_imm_expr (img, std::get<int>($2) >> std::get<int>($6), NULL, false);
+		  $$.p = make_imm_expr (img, $2.i >> $6.i, NULL, false);
 		}
 
 	|	ID
 		{
-		  $$ = make_imm_expr (img, 0, std::get<std::shared_ptr<char>>($1).get(), false);
+		  $$.p = make_imm_expr (img, 0, (char*)$1.p, false);
+          free((char *) $1.p);
 		}
 
 	|	Y_ID '+' ABS_ADDR
 		{
-		  $$ = make_imm_expr (img, std::get<int>($3), std::get<std::shared_ptr<char>>($1).get(), false);
+		  $$.p = make_imm_expr (img, $3.i, (char*)$1.p, false);
+		  free ((char*)$1.p);
 		}
 
 	|	Y_ID '-' ABS_ADDR
 		{
-		  $$ = make_imm_expr (img, - std::get<int>($3), std::get<std::shared_ptr<char>>($1).get(), false);
+		  $$.p = make_imm_expr (img, - $3.i, (char*)$1.p, false);
+		  free ((char*)$1.p);
 		}
 	;
 
@@ -2519,15 +2537,15 @@ IMM32:		ABS_ADDR
 ABS_ADDR:	Y_INT
 
 	|	Y_INT '+' Y_INT
-		{$$ = std::get<int>($1) + std::get<int>($3);}
+		{$$.i = $1.i + $3.i;}
 
 	|	Y_INT Y_INT
 		{
 		  /* This is actually: Y_INT '-' Y_INT, since the binary
 		     subtract operator gets scanned as a unary negation
 		     operator. */
-		  if (std::get<int>($2) >= 0) yyerror (img, "Syntax error");
-		  $$ = std::get<int>($1) - -std::get<int>($2);
+		  if ($2.i >= 0) yyerror (img, "Syntax error");
+		  $$.i = $1.i - -$2.i;
 		}
 	;
 
@@ -2541,9 +2559,9 @@ REG:		REGISTER ;
 
 REGISTER:	Y_REG
 		{
-		  if (std::get<int>($1) < 0 || std::get<int>($1) > 31)
+		  if ($1.i < 0 || $1.i > 31)
 		    yyerror (img, "Register number out of range");
-		  if (std::get<int>($1) == 1 && !bare_machine && !noat_flag)
+		  if ($1.i == 1 && !bare_machine && !noat_flag)
 		    yyerror (img, "Register 1 is reserved for assembler");
 		  $$ = $1;
 		}
@@ -2556,7 +2574,7 @@ F_SRC2:		FP_REGISTER ;
 
 FP_REGISTER:	Y_FP_REG
 		{
-		  if (std::get<int>($1) < 0 || std::get<int>($1) > 31)
+		  if ($1.i < 0 || $1.i > 31)
 		    yyerror (img, "FP register number out of range");
 		  $$ = $1;
 		}
@@ -2564,7 +2582,7 @@ FP_REGISTER:	Y_FP_REG
 
 CC_REG:	       Y_INT
 		{
-		  if (std::get<int>($1) < 0 || std::get<int>($1) > 7)
+		  if ($1.i < 0 || $1.i > 7)
 		    yyerror (img, "CC register number out of range");
 		  $$ = $1;
 		}
@@ -2579,7 +2597,8 @@ COP_REG:	Y_REG
 
 LABEL:		ID
 		{
-		  $$ = make_imm_expr (img, -(int)current_text_pc (img), std::get<std::shared_ptr<char>>($1).get(), true);
+		  $$.p = make_imm_expr (img, -(int)current_text_pc (img), (char*)$1.p, true);
+          free((char *)$1.p);
 		}
 
 
@@ -2590,14 +2609,16 @@ STR_LST:	STR_LST STR
 
 STR:		Y_STR
 		{
-		  store_string (img, std::get<std::shared_ptr<char>>($1).get(), strlen(std::get<std::shared_ptr<char>>($1).get()), null_term);
+		  store_string (img, (char*)$1.p, strlen((char*)$1.p), null_term);
+		  free ((char*)$1.p);
 		}
 	|	Y_STR ':' Y_INT
 		{
 		  int i;
 
-		  for (i = 0; i < std::get<int>($3); i ++)
-		    store_string (img, std::get<std::shared_ptr<char>>($1).get(), strlen(std::get<std::shared_ptr<char>>($1).get()), null_term);
+		  for (i = 0; i < $3.i; i ++)
+		    store_string (img, (char*)$1.p, strlen((char*)$1.p), null_term);
+		  free ((char*)$1.p);
 		}
 	;
 
@@ -2608,65 +2629,66 @@ EXPR:
                 TRM
         |
                 EXPR '+' TRM
-                { $$ =  std::get<int>($1) + std::get<int>($3); }
+                { $$.i =  $1.i + $3.i; }
         |
                 EXPR '-' TRM
-                { $$ =  std::get<int>($1) - std::get<int>($3); }
+                { $$.i =  $1.i - $3.i; }
         ;
 
 TRM:
                 FACTOR
         |
                 TRM '*' FACTOR
-                { $$ = std::get<int>($1) * std::get<int>($3); }
+                { $$.i = $1.i * $3.i; }
         |
                 TRM '/' FACTOR
-                { $$ = std::get<int>($1) / std::get<int>($3); }
+                { $$.i = $1.i / $3.i; }
         ;
 
 FACTOR:         Y_INT
 
         |       '(' EXPR ')'
-                { $$ = std::get<int>($2); }
+                { $$.i = $2.i; }
 
 	|	ID
 		{
-		  label *l = lookup_label (img, std::get<std::shared_ptr<char>>($1).get());
+		  label *l = lookup_label (img, (char*)$1.p);
+          free((char *) $1.p);
   		  if (l->addr == 0)
                     {
                       record_data_uses_symbol (img, current_data_pc (img), l);
-                      $$ = (void *) NULL;
+                      $$.p = NULL;
                     }
                   else
-                    $$ = (int) l->addr;
+                    $$.i = l->addr;
 		}
 
 
 EXPR_LST:	EXPR_LST	EXPRESSION
 		{
-		  store_op (img, std::get<int>($2));
+		  store_op (img, $2.i);
 		}
 	|	EXPRESSION
 		{
-		  store_op (img, std::get<int>($1));
+		  store_op (img, $1.i);
 		}
 	|	EXPRESSION ':' EXPR
 		{
 		  int i;
 
-		  for (i = 0; i < std::get<int>($3); i ++)
-		    store_op (img, std::get<int>($1));
+		  for (i = 0; i < $3.i; i ++)
+		    store_op (img, $1.i);
 		}
 	;
 
 
 FP_EXPR_LST:	FP_EXPR_LST Y_FP
 		{
-		  store_fp_op (img, (double *)std::get<void *>($2));
+		  store_fp_op (img, (double*)$2.p);
 		}
 	|	Y_FP
 		{
-		  store_fp_op (img, (double *)std::get<void *>($1));
+		  store_fp_op (img, (double*)$1.p);
 		}
 	;
 
@@ -2674,7 +2696,7 @@ FP_EXPR_LST:	FP_EXPR_LST Y_FP
 OPTIONAL_ID:	{only_id = 1;} OPT_ID {only_id = 0; $$ = $2;}
 
 OPT_ID:		ID
-	|	{$$ = (void*)NULL;}
+	|	{$$.p = (void*)NULL;}
 	;
 
 

--- a/spim/CPU/parser.y
+++ b/spim/CPU/parser.y
@@ -2647,6 +2647,7 @@ FACTOR:         Y_INT
 	|	ID
 		{
 		  label *l = lookup_label (img, (char*)$1.p);
+          free((char *) $1.p);
   		  if (l->addr == 0)
                     {
                       record_data_uses_symbol (img, current_data_pc (img), l);

--- a/spim/CPU/parser.y
+++ b/spim/CPU/parser.y
@@ -651,9 +651,13 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 		{
 		  int *x = (int *) $3.p;
 
-		  i_type_inst (img, Y_ORI_OP, 1, 0, const_imm_expr (img, *x));
+          imm_expr *const_expr = const_imm_expr (img, *x);
+		  i_type_inst (img, Y_ORI_OP, 1, 0, const_expr);
+          free(const_expr);
 		  r_co_type_inst (img, Y_MTC1_OP, 0, $2.i, 1);
-		  i_type_inst (img, Y_ORI_OP, 1, 0, const_imm_expr (img, *(x+1)));
+          const_expr = const_imm_expr (img, *(x+1));
+		  i_type_inst (img, Y_ORI_OP, 1, 0, const_expr);
+          free(const_expr);
 		  r_co_type_inst (img, Y_MTC1_OP, 0, $2.i + 1, 1);
 		}
 
@@ -663,7 +667,9 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 		  float x = (float) *((double *) $3.p);
 		  int *y = (int *) &x;
 
-		  i_type_inst (img, Y_ORI_OP, 1, 0, const_imm_expr (img, *y));
+          imm_expr *const_expr = const_imm_expr (img, *y);
+		  i_type_inst (img, Y_ORI_OP, 1, 0,const_expr);
+          free(const_expr);
 		  r_co_type_inst (img, Y_MTC1_OP, 0, $2.i, 1);
 		}
 
@@ -1080,13 +1086,16 @@ ASM_CODE:	LOAD_OPS	DEST	ADDRESS
 
 		  if (bare_machine && !accept_pseudo_insts)
 		    yyerror (img, "Immediate form not allowed in bare machine");
-		  else
+		  else {
+            imm_expr *expr = make_imm_expr (img, -val, NULL, false);
 		    i_type_inst (img, $1.i == Y_SUB_OP ? Y_ADDI_OP
 				 : $1.i == Y_SUBU_OP ? Y_ADDIU_OP
 				 : (fatal_error (img, "Bad SUB_OP\n"), 0),
 				 $2.i,
 				 $3.i,
-				 make_imm_expr (img, -val, NULL, false));
+				 expr);
+            free(expr);
+          }
 		  free ((imm_expr *)$4.p);
 		}
 

--- a/spim/CPU/parser.y
+++ b/spim/CPU/parser.y
@@ -2239,6 +2239,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 	|	Y_EXTERN_DIR	ID	EXPR
 		{
 		  extern_directive (img, (char*)$2.p, $3.i);
+          free((char *) $2.p);
 		}
 
 
@@ -2300,6 +2301,7 @@ ASM_DIRECTIVE:	Y_ALIAS_DIR	Y_REG	Y_REG
 	|	Y_LCOMM_DIR	ID	EXPR
 		{
 		  lcomm_directive (img, (char*)$2.p, $3.i);
+          free((char *) $2.p);
 		}
 
 
@@ -2464,6 +2466,7 @@ ADDR:		'(' REGISTER ')'
 	|	ABS_ADDR '+' ID
 		{
 		  $$.p = make_addr_expr (img, $1.i, (char*)$3.p, 0);
+          free((char *) $3.p);
 		}
 
 	|	Y_ID '-' ABS_ADDR
@@ -2514,6 +2517,7 @@ IMM32:		ABS_ADDR
 	|	ID
 		{
 		  $$.p = make_imm_expr (img, 0, (char*)$1.p, false);
+          free((char *) $1.p);
 		}
 
 	|	Y_ID '+' ABS_ADDR
@@ -2594,6 +2598,7 @@ COP_REG:	Y_REG
 LABEL:		ID
 		{
 		  $$.p = make_imm_expr (img, -(int)current_text_pc (img), (char*)$1.p, true);
+          free((char *)$1.p);
 		}
 
 

--- a/spim/CPU/reg_image.h
+++ b/spim/CPU/reg_image.h
@@ -4,6 +4,8 @@
 #include "types.h"
 #include "instruction.h"
 
+#include <stdlib.h>
+
 typedef int32 /*@alt unsigned int @*/ reg_word;
 typedef uint32 u_reg_word;
 
@@ -38,6 +40,15 @@ typedef struct regimage {
 	mem_addr next_k_data_pc;	/* Location for next datum in kernel */
 	mem_addr next_gp_item_addr;	/* Address of next item accessed off $gp */
 	bool auto_alignment = true;
+
+    ~regimage() {
+        /* if (FPR) */
+        /*     free(FPR); */
+        /* if (FGR) */
+        /*     free(FGR); */
+        if (FWR)
+            free(FWR);
+    }
 } reg_image_t;
 
 #endif

--- a/spim/CPU/scanner.h
+++ b/spim/CPU/scanner.h
@@ -31,6 +31,13 @@
 */
 
 #include "image.h"
+#include "instruction.h"
+#include "inst.h"
+
+#include <memory>
+#include <variant>
+
+typedef std::variant<int, void *, addr_expr *, imm_expr *, std::shared_ptr<char>> intptr_union;
 
 /* Exported functions (besides yylex): */
 

--- a/spim/CPU/scanner.h
+++ b/spim/CPU/scanner.h
@@ -46,6 +46,8 @@ char *source_line (MIPSImage &img);
 		int yylex(MIPSImage& img)
 extern YY_DECL;
 
+int yylex_destroy(void);
+
 /* Exported Variables: */
 
 /* This flag tells the scanner to treat the next sequence of letters

--- a/spim/CPU/scanner.h
+++ b/spim/CPU/scanner.h
@@ -31,13 +31,6 @@
 */
 
 #include "image.h"
-#include "instruction.h"
-#include "inst.h"
-
-#include <memory>
-#include <variant>
-
-typedef std::variant<int, void *, addr_expr *, imm_expr *, std::shared_ptr<char>> intptr_union;
 
 /* Exported functions (besides yylex): */
 

--- a/spim/CPU/scanner.l
+++ b/spim/CPU/scanner.l
@@ -196,7 +196,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			  else
 			    {
 			      /* Not-yet defined label */
-			      yylval.p = (char*) str_copy (img, yytext);
+			      yylval.s = std::shared_ptr<char>((char*) str_copy (img, yytext), [] (auto p) { free(p); });
 			      return (Y_ID);
 			    }
 			}
@@ -238,7 +238,7 @@ static char scan_escape (MIPSImage &img, char **str);
 				}
 			      else
 				{
-				  yylval.p = (char*) str_copy (img, yytext);
+				  yylval.s = std::shared_ptr<char>((char*) str_copy (img, yytext), [] (auto p) { free(p); });
 				  return (Y_ID);
 				}
 			    }
@@ -270,7 +270,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			      current_line_no = line_no;
 			      current_line = yytext;
 			    }
-			  yylval.p = (char*) str_copy (img, yytext);
+			  yylval.s = std::shared_ptr<char>((char*) str_copy (img, yytext), [] (auto p) { free(p); });
 			  /* For top level */
 			  return (Y_ID);
 			}
@@ -282,7 +282,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			      current_line_no = line_no;
 			      current_line = yytext;
 			    }
-			  yylval.p = (char*) copy_str (img, yytext + 1, 1);
+			  yylval.s = std::shared_ptr<char>((char*) copy_str (img, yytext + 1, 1), [] (auto p) { free(p); });
 			  return (Y_STR);
 			}
 

--- a/spim/CPU/scanner.l
+++ b/spim/CPU/scanner.l
@@ -556,8 +556,6 @@ erroneous_line (MIPSImage &img)
   int i, c;
   str_stream ss;
 
-  ss_init (&ss);
-
   if (current_line == NULL) return ss_to_string (img, &ss);
 
   /* Print part of line that has been consumed. */

--- a/spim/CPU/scanner.l
+++ b/spim/CPU/scanner.l
@@ -127,7 +127,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			     current_line_no = line_no;
 			     current_line = yytext;
 			   }
-			 yylval = atoi (yytext);
+			 yylval.i = atoi (yytext);
 			 return (Y_INT);
 			}
 
@@ -140,12 +140,12 @@ static char scan_escape (MIPSImage &img, char **str);
 			    }
 			  if (*yytext == '-')
 			    {
-			      sscanf(yytext+3, "%x", (unsigned int*)&(std::get<int>(yylval)));
-			      yylval = - std::get<int>(yylval);
+			      sscanf(yytext+3, "%x", (unsigned int*)&(yylval.i));
+			      yylval.i = -yylval.i;
 			    }
 			  else
 			    {
-			      sscanf(yytext+2, "%x", (unsigned int*)&(std::get<int>(yylval)));
+			      sscanf(yytext+2, "%x", (unsigned int*)&(yylval.i));
 			    }
 			  return (Y_INT);
 			}
@@ -158,7 +158,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			      current_line = yytext;
 			    }
 			  scan_float = atof (yytext);
-			  yylval = (double*) &scan_float;
+			  yylval.p = (double*) &scan_float;
 			  return (Y_FP);
 			}
 
@@ -178,7 +178,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			  if (!only_id && token != 0)
 			    {
 			      /* Keyword */
-			      yylval = token;
+			      yylval.i = token;
 			      current_line = yytext;
 			      return (token);
 			    }
@@ -190,13 +190,13 @@ static char scan_escape (MIPSImage &img, char **str);
 			      && l->const_flag)
 			    {
 			      /* Defined label */
-			      yylval = (int) l->addr;
+			      yylval.i = (int) l->addr;
 			      return (Y_INT);
 			    }
 			  else
 			    {
 			      /* Not-yet defined label */
-			      yylval = std::shared_ptr<char>((char*) str_copy (img, yytext), [](auto p) { free(p); });
+			      yylval.p = (char*) str_copy (img, yytext);
 			      return (Y_ID);
 			    }
 			}
@@ -216,14 +216,14 @@ static char scan_escape (MIPSImage &img, char **str);
 			      && *(yytext + 2) != 'p')
 			    {
 			      /* Floating point register ($f0) */
-			      yylval = reg_no;
+			      yylval.i = reg_no;
 			      return (Y_FP_REG);
 			    }
 
 			  if (0 <= reg_no && reg_no < R_LENGTH)
 			    {
 			      /* Register ($r0) */
-			      yylval = reg_no;
+			      yylval.i = reg_no;
 			      return (Y_REG);
 			    }
 			  else
@@ -233,12 +233,12 @@ static char scan_escape (MIPSImage &img, char **str);
 
 			      if (l != NULL && l->const_flag)
 				{
-				  yylval = (int) l->addr;
+				  yylval.i = (int) l->addr;
 				  return (Y_INT);
 				}
 			      else
 				{
-				  yylval = std::shared_ptr<char>((char*) str_copy (img, yytext), [] (auto p) { free(p); });
+				  yylval.p = (char*) str_copy (img, yytext);
 				  return (Y_ID);
 				}
 			    }
@@ -270,7 +270,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			      current_line_no = line_no;
 			      current_line = yytext;
 			    }
-			  yylval = std::shared_ptr<char>((char*) str_copy (img, yytext), [] (auto p) { free(p); });
+			  yylval.p = (char*) str_copy (img, yytext);
 			  /* For top level */
 			  return (Y_ID);
 			}
@@ -282,7 +282,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			      current_line_no = line_no;
 			      current_line = yytext;
 			    }
-			  yylval = std::shared_ptr<char>((char*) copy_str (img, yytext + 1, 1), [] (auto p) { free(p); });
+			  yylval.p = (char*) copy_str (img, yytext + 1, 1);
 			  return (Y_STR);
 			}
 
@@ -296,11 +296,11 @@ static char scan_escape (MIPSImage &img, char **str);
 			  if (*(yytext + 1) == '\\')
 			    {
 			      char *escape = yytext + 2;
-			      yylval = (int) scan_escape (img, &escape);
+			      yylval.i = (int) scan_escape (img, &escape);
 			    }
 			  else
 			    {
-			      yylval = (int) *(yytext + 1);
+			      yylval.i = (int) *(yytext + 1);
 			    }
 
 			  return (Y_INT);

--- a/spim/CPU/scanner.l
+++ b/spim/CPU/scanner.l
@@ -127,7 +127,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			     current_line_no = line_no;
 			     current_line = yytext;
 			   }
-			 yylval.i = atoi (yytext);
+			 yylval = atoi (yytext);
 			 return (Y_INT);
 			}
 
@@ -140,12 +140,12 @@ static char scan_escape (MIPSImage &img, char **str);
 			    }
 			  if (*yytext == '-')
 			    {
-			      sscanf(yytext+3, "%x", (unsigned int*)&(yylval.i));
-			      yylval.i = -yylval.i;
+			      sscanf(yytext+3, "%x", (unsigned int*)&(std::get<int>(yylval)));
+			      yylval = - std::get<int>(yylval);
 			    }
 			  else
 			    {
-			      sscanf(yytext+2, "%x", (unsigned int*)&(yylval.i));
+			      sscanf(yytext+2, "%x", (unsigned int*)&(std::get<int>(yylval)));
 			    }
 			  return (Y_INT);
 			}
@@ -158,7 +158,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			      current_line = yytext;
 			    }
 			  scan_float = atof (yytext);
-			  yylval.p = (double*) &scan_float;
+			  yylval = (double*) &scan_float;
 			  return (Y_FP);
 			}
 
@@ -178,7 +178,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			  if (!only_id && token != 0)
 			    {
 			      /* Keyword */
-			      yylval.i = token;
+			      yylval = token;
 			      current_line = yytext;
 			      return (token);
 			    }
@@ -190,13 +190,13 @@ static char scan_escape (MIPSImage &img, char **str);
 			      && l->const_flag)
 			    {
 			      /* Defined label */
-			      yylval.i = (int) l->addr;
+			      yylval = (int) l->addr;
 			      return (Y_INT);
 			    }
 			  else
 			    {
 			      /* Not-yet defined label */
-			      yylval.p = (char*) str_copy (img, yytext);
+			      yylval = std::shared_ptr<char>((char*) str_copy (img, yytext), [](auto p) { free(p); });
 			      return (Y_ID);
 			    }
 			}
@@ -216,14 +216,14 @@ static char scan_escape (MIPSImage &img, char **str);
 			      && *(yytext + 2) != 'p')
 			    {
 			      /* Floating point register ($f0) */
-			      yylval.i = reg_no;
+			      yylval = reg_no;
 			      return (Y_FP_REG);
 			    }
 
 			  if (0 <= reg_no && reg_no < R_LENGTH)
 			    {
 			      /* Register ($r0) */
-			      yylval.i = reg_no;
+			      yylval = reg_no;
 			      return (Y_REG);
 			    }
 			  else
@@ -233,12 +233,12 @@ static char scan_escape (MIPSImage &img, char **str);
 
 			      if (l != NULL && l->const_flag)
 				{
-				  yylval.i = (int) l->addr;
+				  yylval = (int) l->addr;
 				  return (Y_INT);
 				}
 			      else
 				{
-				  yylval.p = (char*) str_copy (img, yytext);
+				  yylval = std::shared_ptr<char>((char*) str_copy (img, yytext), [] (auto p) { free(p); });
 				  return (Y_ID);
 				}
 			    }
@@ -270,7 +270,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			      current_line_no = line_no;
 			      current_line = yytext;
 			    }
-			  yylval.p = (char*) str_copy (img, yytext);
+			  yylval = std::shared_ptr<char>((char*) str_copy (img, yytext), [] (auto p) { free(p); });
 			  /* For top level */
 			  return (Y_ID);
 			}
@@ -282,7 +282,7 @@ static char scan_escape (MIPSImage &img, char **str);
 			      current_line_no = line_no;
 			      current_line = yytext;
 			    }
-			  yylval.p = (char*) copy_str (img, yytext + 1, 1);
+			  yylval = std::shared_ptr<char>((char*) copy_str (img, yytext + 1, 1), [] (auto p) { free(p); });
 			  return (Y_STR);
 			}
 
@@ -296,11 +296,11 @@ static char scan_escape (MIPSImage &img, char **str);
 			  if (*(yytext + 1) == '\\')
 			    {
 			      char *escape = yytext + 2;
-			      yylval.i = (int) scan_escape (img, &escape);
+			      yylval = (int) scan_escape (img, &escape);
 			    }
 			  else
 			    {
-			      yylval.i = (int) *(yytext + 1);
+			      yylval = (int) *(yytext + 1);
 			    }
 
 			  return (Y_INT);

--- a/spim/CPU/scanner.l
+++ b/spim/CPU/scanner.l
@@ -50,6 +50,8 @@
 #include <unistd.h>
 #endif
 
+#include <memory>
+
 #define YY_NO_UNISTD_H
 
 /* Exported Variables: */
@@ -59,7 +61,7 @@ int line_no;		/* Line number in input file*/
 
 
 /* Local Variables: */
-static char *file_name;   /* The name of the current file */
+static std::shared_ptr<char> file_name;   /* The name of the current file */
 static int file_name_len; /* To avoid recomputing for each source line */
 
 /* Track which line we are reading and where it began in the buffer. */
@@ -342,8 +344,8 @@ initialize_scanner (FILE *in_file, const char *in_file_name)
   current_line = NULL;
   line_returned = 0;
   eof_returned = 0;
-  file_name = strdup(in_file_name); /* will leak some memory */
-  file_name_len = strlen(file_name);
+  file_name = std::shared_ptr<char>(strdup(in_file_name), [](char *p) { free(p); });
+  file_name_len = strlen(file_name.get());
 }
 
 void
@@ -725,7 +727,7 @@ source_line (MIPSImage &img)
       *eol1 = '\0';
 
       r = (char *) xmalloc (img, eol1 - current_line + 11 + file_name_len);
-      sprintf (r, "%s:%d: %s", file_name, current_line_no, current_line);
+      sprintf (r, "%s:%d: %s", file_name.get(), current_line_no, current_line);
 
       /* Restore end-of-line character and, if necessary, yylex's null byte. */
       *eol1 = c1;

--- a/spim/CPU/spim-utils.cpp
+++ b/spim/CPU/spim-utils.cpp
@@ -705,18 +705,24 @@ zmalloc (MIPSImage &img, int size)
 }
 
 std::string string_vformat(const std::string& format, va_list args) {
+    va_list args_copy;
+    va_copy(args_copy, args);
     int size_s = std::vsnprintf(nullptr, 0, format.c_str(), args) + 1; // Extra space for '\0'
     if( size_s <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
     auto size = static_cast<size_t>(size_s);
     std::unique_ptr<char[]> buf( new char[ size ] );
-    std::vsnprintf(buf.get(), size, format.c_str(), args);
+    std::vsnprintf(buf.get(), size - 1, format.c_str(), args_copy);
+    va_end(args_copy);
     return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
 }
 
 std::pair<char *, int> vformat_alloc(const char *format, va_list args) {
+    va_list args_copy;
+    va_copy(args_copy, args);
     int size = vsnprintf(NULL, 0, format, args) + 1;
     char *formatted_string = new char[size];
-    vsprintf(formatted_string, format, args);
+    vsnprintf(formatted_string, size - 1, format, args_copy);
+    va_end(args_copy);
     return std::make_pair(formatted_string, size - 1);
 }
 

--- a/spim/CPU/spim-utils.cpp
+++ b/spim/CPU/spim-utils.cpp
@@ -157,6 +157,7 @@ initialize_world (MIPSImage &img, const char *exception_files, bool print_messag
 	(void)record_label (img, "main", 0, 0);
       }
     }
+  yylex_destroy();
   initialize_scanner (stdin, "");
   delete_all_breakpoints (img); // bruh TODO: this function is meant to be contextual-based and then we have THIS here?!?!
 }
@@ -223,6 +224,7 @@ read_assembly_file (MIPSImage &img, const char *fpath)
       file_name = strrchr(fpath, '/');
       file_name = file_name == NULL ? fpath : file_name + 1;
     
+      yylex_destroy();
       initialize_scanner (file, file_name);
       initialize_parser (fpath);
 

--- a/spim/CPU/spim-utils.cpp
+++ b/spim/CPU/spim-utils.cpp
@@ -711,9 +711,9 @@ std::string string_vformat(const std::string& format, va_list args) {
     if( size_s <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
     auto size = static_cast<size_t>(size_s);
     std::unique_ptr<char[]> buf( new char[ size ] );
-    std::vsnprintf(buf.get(), size - 1, format.c_str(), args_copy);
+    std::vsnprintf(buf.get(), size, format.c_str(), args_copy);
     va_end(args_copy);
-    return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
+    return std::string( buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
 }
 
 std::pair<char *, int> vformat_alloc(const char *format, va_list args) {
@@ -721,7 +721,7 @@ std::pair<char *, int> vformat_alloc(const char *format, va_list args) {
     va_copy(args_copy, args);
     int size = vsnprintf(NULL, 0, format, args) + 1;
     char *formatted_string = new char[size];
-    vsnprintf(formatted_string, size - 1, format, args_copy);
+    vsnprintf(formatted_string, size, format, args_copy);
     va_end(args_copy);
     return std::make_pair(formatted_string, size - 1);
 }

--- a/spim/CPU/spim.h
+++ b/spim/CPU/spim.h
@@ -88,11 +88,7 @@
 
 
 
-constexpr int K = 1024;
-
-
-#define BYTES_PER_WORD 4	/* On the MIPS processor */
-
+#include "consts.h"
 
 /* Sizes of memory segments. */
 

--- a/spim/CPU/string-stream.cpp
+++ b/spim/CPU/string-stream.cpp
@@ -39,12 +39,6 @@
 #include "string-stream.h"
 
 
-#ifndef SS_BUF_LENGTH
-/* Initialize length of buffer */
-#define SS_BUF_LENGTH 256
-#endif
-
-
 void
 ss_init (str_stream* ss)
 {
@@ -98,7 +92,7 @@ ss_to_string (MIPSImage &img, str_stream* ss)
     }
   ss->buf[ss->empty_pos] = '\0'; /* Null terminate string */
   ss->empty_pos += 1;
-  return ss->buf;
+  return strdup(ss->buf);
 }
 
 

--- a/spim/CPU/string-stream.h
+++ b/spim/CPU/string-stream.h
@@ -35,16 +35,31 @@
 
 #include "image.h"
 
+#ifndef SS_BUF_LENGTH
+/* Initialize length of buffer */
+#define SS_BUF_LENGTH 256
+#endif
+
 typedef struct str_stm
 {
   char* buf;			/* Buffer containing output */
   int max_length;		/* Length of buffer */
   int empty_pos;		/* Index  of empty char in stream*/
   int initialized;		/* Stream initialized? */
+
+  str_stm() {
+    buf = (char *) malloc (SS_BUF_LENGTH);
+    max_length = SS_BUF_LENGTH;
+    empty_pos = 0;
+    initialized = 1;
+  }
+
+  ~str_stm() {
+    free(buf);
+  }
 } str_stream;
 
 
-void ss_init (str_stream* ss);
 void ss_clear (str_stream* ss);
 void ss_erase (str_stream* ss, int n);
 int ss_length (str_stream* ss);

--- a/spim/CPU/sym-tbl.cpp
+++ b/spim/CPU/sym-tbl.cpp
@@ -31,6 +31,7 @@
 */
 
 
+#include "label.h"
 #include "spim.h"
 #include "string-stream.h"
 #include "spim-utils.h"
@@ -78,6 +79,14 @@ initialize_symbol_table (MIPSImage &img)
     for (x = img.get_label_hash_table()[i]; x != NULL; x = n)
     {
       free (x->name);
+      label_use *next_use;
+      for (label_use *curr = x->uses; curr != NULL; curr = next_use) {
+        next_use = curr->next;
+        if (data_dir && curr->inst) {
+          free_inst(curr->inst);
+        }
+        free(curr);
+      }
       n = x->next;
       free (x);
     }

--- a/spim/CPU/sym-tbl.cpp
+++ b/spim/CPU/sym-tbl.cpp
@@ -427,6 +427,7 @@ flush_local_labels (MIPSImage &img, int issue_undef_warnings)
 	      error (img, "Warning: local symbol %s was not defined\n",
 		     entry->name);
 	    /* Can't free label since IMM_EXPR's still reference it */
+        img.push_label_to_free_vector(lab);
 	    break;
 	  }
     }

--- a/spim/CPU/types.h
+++ b/spim/CPU/types.h
@@ -1,7 +1,7 @@
 #pragma once
-
 /* Type declarations for portability.  They work for DEC's Alpha (64 bits)
    and 32 bit machines */
 
 typedef int int32;
 typedef unsigned int  uint32;
+typedef union {int i; void* p;} intptr_union;

--- a/spim/CPU/types.h
+++ b/spim/CPU/types.h
@@ -1,7 +1,7 @@
 #pragma once
+
 /* Type declarations for portability.  They work for DEC's Alpha (64 bits)
    and 32 bit machines */
 
 typedef int int32;
 typedef unsigned int  uint32;
-typedef union {int i; void* p;} intptr_union;

--- a/spim/CPU/types.h
+++ b/spim/CPU/types.h
@@ -1,7 +1,14 @@
 #pragma once
+
+#include <memory>
+
 /* Type declarations for portability.  They work for DEC's Alpha (64 bits)
    and 32 bit machines */
 
 typedef int int32;
 typedef unsigned int  uint32;
-typedef union {int i; void* p;} intptr_union;
+typedef struct {
+    int i;
+    void *p;
+    std::shared_ptr<char> s;
+} intptr_union;

--- a/spim/worker.cpp
+++ b/spim/worker.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <condition_variable>
 
+#include "CPU/scanner.h"
 #include "CPU/spim-utils.h"
 #include "CPU/spim.h"
 
@@ -81,6 +82,7 @@ void reset(unsigned int max_contexts, std::set<unsigned int> &active_ctxs) {
         } else {
             ctxs.erase(i);
         }
+        yylex_destroy();
     }
     finished = false;
     steps_left = 0;


### PR DESCRIPTION
There were a bunch of memory leaks throughout the library (including the `MIPSImage` class itself).

This PR resolves:
- A `MIPSImage` destructor (resolves a vast majority of the memory leaks)
- Multiple leaks within the original Spim library

From what I know and have tested, there are no memory leaks within Spim now! I am still a bit skeptical whether or not a certain assembly files when parsed will cause a memory leak, but this is quite good enough imho.