### PR TITLE
Added move constructor for `MIPSImage`

### DIFF
--- a/spim/CPU/image.cpp
+++ b/spim/CPU/image.cpp
@@ -16,6 +16,19 @@ MIPSImage::~MIPSImage() {
     }
 }
 
+MIPSImage::MIPSImage(const MIPSImage &&other) :
+    ctx(other.ctx),
+    bkpt_map(std::move(other.bkpt_map)),
+    local_labels(other.local_labels),
+    labels_to_free(std::move(other.labels_to_free)),
+    std_out(std::move(other.std_out)),
+    std_err(std::move(other.std_err))
+{
+    for (size_t i = 0; i < LABEL_HASH_TABLE_SIZE; i++) {
+        label_hash_table[i] = other.label_hash_table[i];
+    }
+}
+
 int MIPSImage::get_ctx() const {
     return ctx;
 }

--- a/spim/CPU/image.cpp
+++ b/spim/CPU/image.cpp
@@ -24,17 +24,24 @@ MIPSImage::~MIPSImage() {
         free(label_hash_table);
 }
 
-MIPSImage::MIPSImage(const MIPSImage &&other) :
+MIPSImage::MIPSImage(MIPSImage &&other) :
     ctx(other.ctx),
-    mem_img(other.mem_img),
-    reg_img(other.reg_img),
+    mem_img(std::move(other.mem_img)),
+    reg_img(std::move(other.reg_img)),
     bkpt_map(std::move(other.bkpt_map)),
     local_labels(other.local_labels),
     label_hash_table(other.label_hash_table),
     labels_to_free(std::move(other.labels_to_free)),
     std_out(std::move(other.std_out)),
     std_err(std::move(other.std_err))
-{}
+{
+    other.mem_img = {};
+    other.reg_img = {};
+    other.bkpt_map.clear();
+    other.local_labels = NULL;
+    other.label_hash_table = NULL;
+    other.labels_to_free.clear();
+}
 
 int MIPSImage::get_ctx() const {
     return ctx;

--- a/spim/CPU/image.cpp
+++ b/spim/CPU/image.cpp
@@ -15,13 +15,7 @@ MIPSImage::MIPSImage(int ctx) :
 }
 
 MIPSImage::~MIPSImage() {
-    initialize_symbol_table(*this);
-    for (auto it = labels_to_free.begin(); it != labels_to_free.end(); it ++) {
-        free((*it)->name);
-        free(*it);
-    }
-    if (label_hash_table)
-        free(label_hash_table);
+    free_internals();
 }
 
 MIPSImage::MIPSImage(MIPSImage &&other) :
@@ -41,6 +35,37 @@ MIPSImage::MIPSImage(MIPSImage &&other) :
     other.local_labels = NULL;
     other.label_hash_table = NULL;
     other.labels_to_free.clear();
+}
+
+MIPSImage &MIPSImage::operator=(MIPSImage &&other) {
+    free_internals();
+    ctx = other.ctx;
+    mem_img = std::move(other.mem_img);
+    reg_img = std::move(other.reg_img);
+    bkpt_map = std::move(other.bkpt_map);
+    local_labels = other.local_labels;
+    label_hash_table = other.label_hash_table;
+    labels_to_free = std::move(other.labels_to_free);
+    std_out = std::move(other.std_out);
+    std_err = std::move(other.std_err);
+
+    other.mem_img = {};
+    other.reg_img = {};
+    other.local_labels = NULL;
+    other.label_hash_table = NULL;
+    other.labels_to_free.clear();
+
+    return *this;
+}
+
+void MIPSImage::free_internals() {
+    initialize_symbol_table(*this);
+    for (auto it = labels_to_free.begin(); it != labels_to_free.end(); it ++) {
+        free((*it)->name);
+        free(*it);
+    }
+    if (label_hash_table)
+        free(label_hash_table);
 }
 
 int MIPSImage::get_ctx() const {

--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -30,7 +30,7 @@ class MIPSImage {
     std::unordered_map<mem_addr, breakpoint> bkpt_map;
     // std::unordered_map<mem_addr, label> labels;
     label *local_labels = NULL; // No allocs occur here
-    label *label_hash_table[LABEL_HASH_TABLE_SIZE] = {0};
+    label **label_hash_table = NULL; // Points to an array of size LABEL_HASH_TABLE_SIZE
     std::vector<label *> labels_to_free;
 
     MIPSImagePrintStream std_out;

--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -35,11 +35,16 @@ class MIPSImage {
 
     MIPSImagePrintStream std_out;
     MIPSImagePrintStream std_err;
+
+    void free_internals();
   public:
     MIPSImage(int ctx);
     ~MIPSImage();
     MIPSImage(const MIPSImage&) = delete;
     MIPSImage(MIPSImage&&);
+
+    MIPSImage &operator=(MIPSImage &) = delete;
+    MIPSImage &operator=(MIPSImage &&);
 
     int get_ctx() const;
 

--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -39,7 +39,7 @@ class MIPSImage {
     MIPSImage(int ctx);
     ~MIPSImage();
     MIPSImage(const MIPSImage&) = delete;
-    MIPSImage(const MIPSImage&&);
+    MIPSImage(MIPSImage&&);
 
     int get_ctx() const;
 

--- a/spim/CPU/image.h
+++ b/spim/CPU/image.h
@@ -38,6 +38,8 @@ class MIPSImage {
   public:
     MIPSImage(int ctx);
     ~MIPSImage();
+    MIPSImage(const MIPSImage&) = delete;
+    MIPSImage(const MIPSImage&&);
 
     int get_ctx() const;
 

--- a/spim/CPU/image_print_stream.cpp
+++ b/spim/CPU/image_print_stream.cpp
@@ -21,6 +21,18 @@ MIPSImagePrintStream::~MIPSImagePrintStream() {
     sync(); // Flush the buffer on exit
 }
 
+MIPSImagePrintStream::MIPSImagePrintStream(const MIPSImagePrintStream &&other) :
+    ctx(other.ctx),
+    sink(other.sink),
+    buf(std::move(other.buf))
+{
+    char *base = &buf.front();
+    setp(base, base + buf.size() - 1);
+
+    size_t offset = other.pptr() - other.pbase();
+    pbump(offset);
+}
+
 std::streamsize MIPSImagePrintStream::xsputn(const char *s, std::streamsize n) {
     std::streamsize char_pos = 0;
     while (char_pos < n) {

--- a/spim/CPU/image_print_stream.cpp
+++ b/spim/CPU/image_print_stream.cpp
@@ -29,7 +29,7 @@ MIPSImagePrintStream::MIPSImagePrintStream(MIPSImagePrintStream &&other) :
     char *base = &buf.front();
     setp(base, base + buf.size() - 1);
 
-    reset_other_buffer(std::move(other));
+    move_buffer_pointers(std::move(other));
 }
 
 MIPSImagePrintStream& MIPSImagePrintStream::operator=(MIPSImagePrintStream &&other) {
@@ -40,10 +40,11 @@ MIPSImagePrintStream& MIPSImagePrintStream::operator=(MIPSImagePrintStream &&oth
     char *base = &buf.front();
     setp(base, base + buf.size() - 1);
 
-    reset_other_buffer(std::move(other));
+    move_buffer_pointers(std::move(other));
+    return *this;
 }
 
-void inline MIPSImagePrintStream::reset_other_buffer(MIPSImagePrintStream &&other) {
+inline void MIPSImagePrintStream::move_buffer_pointers(MIPSImagePrintStream &&other) {
     int offset = other.pptr() - other.pbase();
     pbump(offset);
     other.pbump(-offset);

--- a/spim/CPU/image_print_stream.cpp
+++ b/spim/CPU/image_print_stream.cpp
@@ -21,7 +21,7 @@ MIPSImagePrintStream::~MIPSImagePrintStream() {
     sync(); // Flush the buffer on exit
 }
 
-MIPSImagePrintStream::MIPSImagePrintStream(const MIPSImagePrintStream &&other) :
+MIPSImagePrintStream::MIPSImagePrintStream(MIPSImagePrintStream &&other) :
     ctx(other.ctx),
     sink(other.sink),
     buf(std::move(other.buf))
@@ -29,8 +29,9 @@ MIPSImagePrintStream::MIPSImagePrintStream(const MIPSImagePrintStream &&other) :
     char *base = &buf.front();
     setp(base, base + buf.size() - 1);
 
-    size_t offset = other.pptr() - other.pbase();
+    int offset = other.pptr() - other.pbase();
     pbump(offset);
+    other.pbump(-offset);
 }
 
 std::streamsize MIPSImagePrintStream::xsputn(const char *s, std::streamsize n) {
@@ -63,6 +64,9 @@ MIPSImagePrintStream::int_type MIPSImagePrintStream::overflow(MIPSImagePrintStre
 int MIPSImagePrintStream::sync() {
     std::ptrdiff_t n = pptr() - pbase();
     pbump(-n);
+    if (!n) {
+        return 0;
+    }
 #ifdef WASM
     char *s = new char[n + 1];
     strncpy(s, pbase(), n);

--- a/spim/CPU/image_print_stream.h
+++ b/spim/CPU/image_print_stream.h
@@ -22,6 +22,7 @@ class MIPSImagePrintStream : public std::streambuf {
     public:
         explicit MIPSImagePrintStream(unsigned int ctx, std::ostream &sink, std::size_t buffer_size = 256); 
         MIPSImagePrintStream(const MIPSImagePrintStream&) = delete;
+        MIPSImagePrintStream(const MIPSImagePrintStream&&);
         MIPSImagePrintStream& operator=(const MIPSImagePrintStream&) = delete;
         ~MIPSImagePrintStream();
 

--- a/spim/CPU/image_print_stream.h
+++ b/spim/CPU/image_print_stream.h
@@ -28,7 +28,7 @@ class MIPSImagePrintStream : public std::streambuf {
         ~MIPSImagePrintStream();
 
     private:
-        void reset_other_buffer(MIPSImagePrintStream &&other);
+        inline void move_buffer_pointers(MIPSImagePrintStream &&other);
         std::streamsize xsputn(const char *s, std::streamsize n);
         int_type overflow(int_type ch);
         int sync();

--- a/spim/CPU/image_print_stream.h
+++ b/spim/CPU/image_print_stream.h
@@ -24,15 +24,17 @@ class MIPSImagePrintStream : public std::streambuf {
         MIPSImagePrintStream(const MIPSImagePrintStream&) = delete;
         MIPSImagePrintStream(MIPSImagePrintStream&&);
         MIPSImagePrintStream& operator=(const MIPSImagePrintStream&) = delete;
+        MIPSImagePrintStream& operator=(MIPSImagePrintStream&&);
         ~MIPSImagePrintStream();
 
     private:
+        void reset_other_buffer(MIPSImagePrintStream &&other);
         std::streamsize xsputn(const char *s, std::streamsize n);
         int_type overflow(int_type ch);
         int sync();
 
         unsigned int ctx;
-        std::ostream &sink;
+        std::ostream *sink;
         std::vector<char> buf;
 };
 

--- a/spim/CPU/image_print_stream.h
+++ b/spim/CPU/image_print_stream.h
@@ -22,7 +22,7 @@ class MIPSImagePrintStream : public std::streambuf {
     public:
         explicit MIPSImagePrintStream(unsigned int ctx, std::ostream &sink, std::size_t buffer_size = 256); 
         MIPSImagePrintStream(const MIPSImagePrintStream&) = delete;
-        MIPSImagePrintStream(const MIPSImagePrintStream&&);
+        MIPSImagePrintStream(MIPSImagePrintStream&&);
         MIPSImagePrintStream& operator=(const MIPSImagePrintStream&) = delete;
         ~MIPSImagePrintStream();
 

--- a/spim/CPU/image_print_stream.h
+++ b/spim/CPU/image_print_stream.h
@@ -14,9 +14,6 @@
  * will append it to the frontend div and append it to an array for the ctx's stdout or stderr.
  *
  * If compiled for unix, it will simply forward it to std::cout/std::cerr.
- *
- * It's unclear if we currently want to add std::ostream to the constructor, but that's an idea that
- * can be implemented if needed.
  */
 class MIPSImagePrintStream : public std::streambuf {
     public:
@@ -34,6 +31,12 @@ class MIPSImagePrintStream : public std::streambuf {
         int sync();
 
         unsigned int ctx;
+        // Note that this cannot be a reference type as std::ostream doesn't implement a public
+        // copy/move constructor. As such, when it comes to the assignment overloads, if sink was a
+        // `std::ostream &`, we cannot simply assign `this->sink = other.sink`. A pointer achieves
+        // the desired result without having using ostream's protected move assignment.
+        // Note: The use of a pointer rather than a reference makes no difference if the original
+        // ostream goes out of scope and gets destroyed.
         std::ostream *sink;
         std::vector<char> buf;
 };

--- a/spim/CPU/mem.cpp
+++ b/spim/CPU/mem.cpp
@@ -227,6 +227,8 @@ void mem_dump_profile(MIPSImage &img) {
 void
 free_instructions (instruction **inst, int n)
 {
+  if (!inst)
+    return;
   for ( ; n > 0; n --, inst ++)
     if (*inst)
       free_inst (*inst);

--- a/spim/CPU/sym-tbl.cpp
+++ b/spim/CPU/sym-tbl.cpp
@@ -70,6 +70,8 @@ static void resolve_a_label_sub (MIPSImage &img, label *sym, instruction *inst, 
 void
 initialize_symbol_table (MIPSImage &img)
 {
+  if (!img.get_label_hash_table())
+    return;
   int i;
 
   for (i = 0; i < LABEL_HASH_TABLE_SIZE; i ++)

--- a/spim/worker.cpp
+++ b/spim/worker.cpp
@@ -73,18 +73,13 @@ void reset(unsigned int max_contexts, std::set<unsigned int> &active_ctxs) {
             continue;
         }
         MIPSImage new_image(i);
-        /* ctxs.emplace(i, i); */
-        /* MIPSImage &new_image = ctxs.at(i); */
         initialize_world(new_image, DEFAULT_EXCEPTION_HANDLER, false);
         initialize_run_stack(new_image, 0, nullptr);
         char file_name[64];
         sprintf(file_name, "./input_%d.s", i);
         if (read_assembly_file(new_image, file_name)) { // check if the file exists
             new_image.reg_image().PC = starting_address(new_image);
-            /* ctxs.emplace(i, std::move(new_image)); */
             ctxs.emplace(i, std::move(new_image));
-        } else {
-            /* ctxs.erase(i); */
         }
         yylex_destroy();
     }

--- a/spim/worker.cpp
+++ b/spim/worker.cpp
@@ -71,16 +71,18 @@ void reset(unsigned int max_contexts, std::set<unsigned int> &active_ctxs) {
         if (i >= max_contexts) {
             continue;
         }
-        ctxs.emplace(i, i);
-        MIPSImage &new_image = ctxs.at(i);
-        initialize_world(new_image, DEFAULT_EXCEPTION_HANDLER, false);
-        initialize_run_stack(new_image, 0, nullptr);
+        MIPSImage *new_image = new MIPSImage(i);
+        /* ctxs.emplace(i, i); */
+        /* MIPSImage &new_image = ctxs.at(i); */
+        initialize_world(*new_image, DEFAULT_EXCEPTION_HANDLER, false);
+        initialize_run_stack(*new_image, 0, nullptr);
         char file_name[64];
         sprintf(file_name, "./input_%d.s", i);
-        if (read_assembly_file(new_image, file_name)) { // check if the file exists
-            new_image.reg_image().PC = starting_address(new_image);
+        if (read_assembly_file(*new_image, file_name)) { // check if the file exists
+            new_image->reg_image().PC = starting_address(*new_image);
+            ctxs.emplace(i, std::move(*new_image));
         } else {
-            ctxs.erase(i);
+            /* ctxs.erase(i); */
         }
         yylex_destroy();
     }

--- a/spim/worker.cpp
+++ b/spim/worker.cpp
@@ -50,7 +50,7 @@ void start_simulator(unsigned int max_contexts, std::set<unsigned int> active_ct
     // Actually, what if we can use the proxy queue? Idk how useful that would be
 }
 
-void reset(unsigned int max_contexts, std::set<unsigned int> &active_ctxs) {
+void shutdown() {
     {
         std::lock_guard<std::mutex> lock(settings_mtx);
         finished = true;
@@ -60,6 +60,10 @@ void reset(unsigned int max_contexts, std::set<unsigned int> &active_ctxs) {
     if (simulator_thread.joinable()) {
         simulator_thread.join();
     }
+}
+
+void reset(unsigned int max_contexts, std::set<unsigned int> &active_ctxs) {
+    shutdown();
 
     // Since we join if a thread already exists, we dont need to lock. YIPPEE!
     /* std::lock(simulator_mtx, settings_mtx); */

--- a/spim/worker.cpp
+++ b/spim/worker.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <thread>
 #include <condition_variable>
+#include <utility>
 
 #include "CPU/scanner.h"
 #include "CPU/spim-utils.h"
@@ -71,16 +72,17 @@ void reset(unsigned int max_contexts, std::set<unsigned int> &active_ctxs) {
         if (i >= max_contexts) {
             continue;
         }
-        MIPSImage *new_image = new MIPSImage(i);
+        MIPSImage new_image(i);
         /* ctxs.emplace(i, i); */
         /* MIPSImage &new_image = ctxs.at(i); */
-        initialize_world(*new_image, DEFAULT_EXCEPTION_HANDLER, false);
-        initialize_run_stack(*new_image, 0, nullptr);
+        initialize_world(new_image, DEFAULT_EXCEPTION_HANDLER, false);
+        initialize_run_stack(new_image, 0, nullptr);
         char file_name[64];
         sprintf(file_name, "./input_%d.s", i);
-        if (read_assembly_file(*new_image, file_name)) { // check if the file exists
-            new_image->reg_image().PC = starting_address(*new_image);
-            ctxs.emplace(i, std::move(*new_image));
+        if (read_assembly_file(new_image, file_name)) { // check if the file exists
+            new_image.reg_image().PC = starting_address(new_image);
+            /* ctxs.emplace(i, std::move(new_image)); */
+            ctxs.emplace(i, std::move(new_image));
         } else {
             /* ctxs.erase(i); */
         }

--- a/spim/worker.h
+++ b/spim/worker.h
@@ -20,6 +20,7 @@ extern bool simulator_ready;
 void start_simulator(unsigned int max_contexts, std::set<unsigned int> active_ctxs);
 
 void reset(unsigned int max_contexts, std::set<unsigned int> &active_ctxs);
+void shutdown();
 void step_simulation(unsigned additional_steps);
 void play_simulation();
 void pause_simulation();


### PR DESCRIPTION
This PR adds a move constructor to `MIPSImage`.

There is some debate about whether to add a copy constructor (which would come in handy if we don't want to prepare the original assembly file, can technically (although seems rather inefficiently) allow the ability to rollback the state of the MIPS program to an earlier point in time).

Adding a copy constructor would require the use of `malloc()` to make sure that it is a deep copy rather than a shallow copy. It is sort of unclear as to what needs to be copied over as there are a lot of source pointers (pointers that were created by `malloc()`) and referential pointers (pointers that were shallow copied).